### PR TITLE
после отправки крипты редиректить на #/btc/tx/.

### DIFF
--- a/shared/components/controls/ShareButton/ShareButton.js
+++ b/shared/components/controls/ShareButton/ShareButton.js
@@ -17,9 +17,15 @@ export default class ShareButton extends React.Component {
       title: title
     })
   }
+
   render() {
+    const {
+      halfWidth,
+      minWidth,
+    } = this.props
+
     return (
-      <div styleName="WrapShareButton">
+      <div styleName={`WrapShareButton ${(halfWidth) ? 'halfWidth' : ''}`}>
         <Button blue onClick={this.openShareModal} type="button" title="Share this article">
           <span>
             <img src={shareIcon} alt='Share' />

--- a/shared/components/controls/ShareButton/ShareButton.scss
+++ b/shared/components/controls/ShareButton/ShareButton.scss
@@ -2,6 +2,7 @@
 
   display: inline-block;
   padding-left: 15px;
+
   svg {
     width: 20px;
     height: 20px;
@@ -9,5 +10,18 @@
   }
   img {
     margin-right: 7px;
+  }
+}
+
+.halfWidth {
+  width: 200px;
+  button {
+    width: 100%;
+  }
+}
+
+@include media-mobile {
+  .halfWidth {
+    width: 50%;
   }
 }

--- a/shared/components/modals/BtcMultisignConfirmTx/BtcMultisignConfirmTx.js
+++ b/shared/components/modals/BtcMultisignConfirmTx/BtcMultisignConfirmTx.js
@@ -23,6 +23,9 @@ import { isMobile } from 'react-device-detect'
 
 import links from 'helpers/links'
 
+import redirectTo from 'helpers/redirectTo'
+
+
 
 const langPrefix = `multiSignConfirmTxModal`
 const langLabels = defineMessages({
@@ -141,6 +144,7 @@ export default class BtcMultisignConfirmTx extends React.Component {
     if (txID && txID.txid) {
       this.handleClose()
 
+      /*
       const infoPayData = {
         amount: `${txData.amount}`,
         currency: 'BTC (Multisig)',
@@ -151,6 +155,10 @@ export default class BtcMultisignConfirmTx extends React.Component {
       }
 
       actions.modals.open(constants.modals.InfoPay, infoPayData)
+      */
+
+      const txInfoUrl = helpers.transactions.getTxRouter('btc', txID.txid)
+      redirectTo(txInfoUrl)
     } else {
       console.log(txID)
       this.setState({

--- a/shared/components/modals/InfoPay/InfoPay.js
+++ b/shared/components/modals/InfoPay/InfoPay.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import { Modal } from 'components/modal'
 import { FormattedMessage, defineMessages, injectIntl } from 'react-intl'
 import helpers from "helpers";
+import { getFullOrigin } from 'helpers/links'
 
 import cssModules from 'react-css-modules'
 import styles from './InfoPay.scss'
@@ -25,7 +26,8 @@ const labels = defineMessages({
   Text: {
     id: 'InfoPay_2',
     defaultMessage: 'successfully transferred to'
-  }
+  },
+  
 })
 @injectIntl
 @cssModules({
@@ -105,17 +107,21 @@ export default class InfoPay extends React.Component {
 
 
     console.log('InfoPay render', this.props.data)
-    let link = '#';
-    let tx = '';
+    
+    let linkBlockChain = '#'
+    let linkShare = '#'
+    let tx = ''
   
     if(txRaw) {
       const txInfo = helpers.transactions.getInfo(currency.toLowerCase(), txRaw)
       tx = txInfo.tx
-      link = txInfo.link
+      linkBlockChain = txInfo.link
     }
+
     if (txId) {
       tx = txId
-      link = helpers.transactions.getLink(currency.toLowerCase(), txId)
+      linkShare = helpers.transactions.getTxRouter(currency.toLowerCase(), txId)
+      linkBlockChain = helpers.transactions.getLink(currency.toLowerCase(), txId)
     }
 
     // @ToDo need to find out oldbalance
@@ -124,7 +130,7 @@ export default class InfoPay extends React.Component {
                         </div>
 
     return (
-      <Modal name={name} title={intl.formatMessage(labels.Title)} showCloseButton={false}>
+      <Modal name={name} title={intl.formatMessage(labels.Title)} onClose={this.handleClose} showCloseButton={true}>
         <div styleName="blockCenter">
           <div>
             <img styleName="finishImg" src={finishSvg} alt="finish" />
@@ -145,11 +151,13 @@ export default class InfoPay extends React.Component {
           <table styleName="blockCenter__table" className="table table-borderless">
             <tbody>
               <tr>
-                <td styleName="header">
+                <td styleName="header" colspan="2">
                   <FormattedMessage id="InfoPay_3" defaultMessage="Transaction ID" />
                 </td>
-                <td>
-                  <a href={link} target="_blank"><ShortTextView text={tx} /></a>
+              </tr>
+              <tr>
+                <td colspan="2">
+                  <a href={linkBlockChain} target="_blank" styleName="txLink">{tx}</a>
                 </td>
               </tr>
               {isFetching ? (
@@ -193,11 +201,14 @@ export default class InfoPay extends React.Component {
           </table>
         </div>
         <div styleName="blockCenter buttonHolder">
-          <Button blue onClick={this.handleClose} type="button" title="Back to app">
+        {/*<Button blue onClick={this.handleClose} type="button" title="Back to app">
             <FormattedMessage id="InfoPay_5" defaultMessage="Back to app" />
-          </Button>
-          {isMobile && <ShareButton link={link} title={amount.toString() + ' ' + currency.toString() + ' ' + intl.formatMessage(labels.Text) + ' ' + toAddress} />
-          }
+  </Button>*/}
+          <ShareButton
+            halfWidth={true}
+            minWidth="200px"
+            link={`${getFullOrigin()}${linkShare}`}
+            title={amount.toString() + ' ' + currency.toString() + ' ' + intl.formatMessage(labels.Text) + ' ' + toAddress} />
         </div>
       </Modal>
     )

--- a/shared/components/modals/InfoPay/InfoPay.js
+++ b/shared/components/modals/InfoPay/InfoPay.js
@@ -105,13 +105,10 @@ export default class InfoPay extends React.Component {
       confirmed,
     } = this.state
 
-
-    console.log('InfoPay render', this.props.data)
-    
     let linkBlockChain = '#'
     let linkShare = '#'
     let tx = ''
-  
+
     if(txRaw) {
       const txInfo = helpers.transactions.getInfo(currency.toLowerCase(), txRaw)
       tx = txInfo.tx
@@ -201,9 +198,6 @@ export default class InfoPay extends React.Component {
           </table>
         </div>
         <div styleName="blockCenter buttonHolder">
-        {/*<Button blue onClick={this.handleClose} type="button" title="Back to app">
-            <FormattedMessage id="InfoPay_5" defaultMessage="Back to app" />
-  </Button>*/}
           <ShareButton
             halfWidth={true}
             minWidth="200px"

--- a/shared/components/modals/InfoPay/InfoPay.scss
+++ b/shared/components/modals/InfoPay/InfoPay.scss
@@ -14,6 +14,9 @@
   margin-bottom: 2rem;
 }
 
+.txLink {
+  word-break: break-all;
+}
 .shortInfoHolder {
   padding-bottom: 2rem;
 }

--- a/shared/components/modals/Share/Share.js
+++ b/shared/components/modals/Share/Share.js
@@ -8,10 +8,25 @@ import actions from 'redux/actions'
 import Button from 'components/controls/Button/Button'
 
 
+
+const langLabels = {
+  copyLink: {
+    id: 'ShareModal1',
+    defaultMessage: 'Copy Link',
+  },
+  linkCopied: {
+    id: 'ShareModal_LinkCopied',
+    defaultMessage: 'Link copied',
+  },
+}
+
 @injectIntl
 @cssModules(styles, { allowMultiple: true })
-
 export default class Share extends Component {
+
+  state = {
+    isLinkCopied: false,
+  }
 
   componentDidMount = () => {
     const { props: { data: { link, title } } } = this
@@ -26,8 +41,30 @@ export default class Share extends Component {
     }
   }
 
+  handleCopyLink = () => {
+    this.setState({
+      isLinkCopied: true,
+    }, () => {
+      setTimeout( () => {
+        this.setState({
+          isLinkCopied: false,
+        })
+      }, 1000)
+    })
+  }
+
   render() {
-    const { props: { data: { link, title } } } = this
+    const {
+      props: {
+        data: {
+          link,
+          title,
+        },
+      },
+      state: {
+        isLinkCopied,
+      },
+    } = this
 
     let name = 'ShareModal';
     let titleModal = 'Share';
@@ -52,20 +89,24 @@ export default class Share extends Component {
             <span>Email</span>
           </a>
         </span>
-        <div styleName="link">
-          <div styleName="pen-url">
-            <span>{link}</span>
-            <span>{link}</span> 
-          </div>
-          <CopyToClipboard text={link}>
-            <Button blue>
-              <FormattedMessage
-                id="ShareModal1"
-                defaultMessage="Copy Link"
-              />
+        <div styleName="copyButtonHolder">
+          <CopyToClipboard
+            text={link}
+            onCopy={this.handleCopyLink}
+          >
+            <Button blue disabled={isLinkCopied}>
+              <FormattedMessage { ... ((isLinkCopied) ? langLabels.linkCopied : langLabels.copyLink) } />
             </Button>
           </CopyToClipboard>
         </div>
+        <CopyToClipboard
+            text={link}
+            onCopy={this.handleCopyLink}
+          >
+          <div styleName="link">
+            <span>{link}</span>
+          </div>
+        </CopyToClipboard>
       </Modal>
     )
   }

--- a/shared/components/modals/Share/Share.js
+++ b/shared/components/modals/Share/Share.js
@@ -9,7 +9,7 @@ import Button from 'components/controls/Button/Button'
 
 
 
-const langLabels = {
+const langLabels = defineMessages({
   copyLink: {
     id: 'ShareModal1',
     defaultMessage: 'Copy Link',
@@ -18,7 +18,7 @@ const langLabels = {
     id: 'ShareModal_LinkCopied',
     defaultMessage: 'Link copied',
   },
-}
+})
 
 @injectIntl
 @cssModules(styles, { allowMultiple: true })

--- a/shared/components/modals/Share/Share.scss
+++ b/shared/components/modals/Share/Share.scss
@@ -46,6 +46,18 @@
   padding: 10px;
   border-radius: 4px;
   background-color: #eee;
+  max-width: 500px;
+  word-break: break-all;
+  cursor: pointer;
+}
+
+.copyButtonHolder {
+  margin: 1rem auto;
+  button {
+    width: 50%;
+    display: block;
+    margin: 0 auto;
+  }
 }
 
 .pen-url {

--- a/shared/components/modals/WithdrawModal/WithdrawModal.js
+++ b/shared/components/modals/WithdrawModal/WithdrawModal.js
@@ -4,7 +4,9 @@ import helpers, { constants } from "helpers";
 import actions from "redux/actions";
 import Link from "sw-valuelink";
 import { connect } from "redaction";
-import config from "app-config";
+import config from 'helpers/externalConfig'
+import { localisedUrl } from 'helpers/locale'
+
 
 import cssModules from "react-css-modules";
 import styles from "./WithdrawModal.scss";
@@ -185,8 +187,12 @@ export default class WithdrawModal extends React.Component {
     const {
       data: { currency, address, balance, invoice, onReady },
       name,
-      history
+      history,
+      intl: {
+        locale,
+      },
     } = this.props;
+
 
     this.setState(() => ({ isShipped: true }));
 
@@ -242,7 +248,8 @@ export default class WithdrawModal extends React.Component {
           address: to
         });*/
         
-             
+
+        /*
         actions.modals.open(constants.modals.InfoPay, {
           amount,
           currency,
@@ -251,11 +258,20 @@ export default class WithdrawModal extends React.Component {
           txRaw: txRaw,
           toAddress: to
         })
+        */
 
         this.setState(() => ({ isShipped: false, error: false }));
         if (onReady instanceof Function) {
           onReady();
         }
+
+        // Redirect to tx
+        const txInfo = helpers.transactions.getInfo(currency.toLowerCase(), txRaw)
+        const { tx: txId } = txInfo
+
+        const txInfoUrl = helpers.transactions.getTxRouter(currency.toLowerCase(), txId)
+
+        history.push(localisedUrl(locale, txInfoUrl))
       })
       .then(() => {
         actions.modals.close(name);

--- a/shared/components/modals/WithdrawModal/WithdrawModal.js
+++ b/shared/components/modals/WithdrawModal/WithdrawModal.js
@@ -26,7 +26,10 @@ import InvoiceInfoBlock from "components/InvoiceInfoBlock/InvoiceInfoBlock";
 // import isCoinAddress from 'swap.app/util/typeforce'
 import typeforce from "swap.app/util/typeforce";
 import minAmount from "helpers/constants/minAmount";
-import { inputReplaceCommaWithDot } from "helpers/domUtils";
+import { inputReplaceCommaWithDot } from "helpers/domUtils"
+
+import redirectTo from 'helpers/redirectTo'
+
 
 @injectIntl
 @connect(
@@ -262,7 +265,7 @@ export default class WithdrawModal extends React.Component {
 
         this.setState(() => ({ isShipped: false, error: false }));
         if (onReady instanceof Function) {
-          onReady();
+          onReady()
         }
 
         // Redirect to tx
@@ -270,8 +273,8 @@ export default class WithdrawModal extends React.Component {
         const { tx: txId } = txInfo
 
         const txInfoUrl = helpers.transactions.getTxRouter(currency.toLowerCase(), txId)
+        redirectTo(txInfoUrl)
 
-        history.push(localisedUrl(locale, txInfoUrl))
       })
       .then(() => {
         actions.modals.close(name);

--- a/shared/components/modals/WithdrawModalMultisig/WithdrawModalMultisig.js
+++ b/shared/components/modals/WithdrawModalMultisig/WithdrawModalMultisig.js
@@ -27,6 +27,9 @@ import minAmount from 'helpers/constants/minAmount'
 import { inputReplaceCommaWithDot } from 'helpers/domUtils'
 import QrReader from "components/QrReader";
 
+import redirectTo from 'helpers/redirectTo'
+
+
 
 @injectIntl
 @connect(
@@ -184,6 +187,7 @@ export default class WithdrawModalMultisig extends React.Component {
     }
     this.setBalanceOnState(currency)
 
+    /*
     actions.modals.open(constants.modals.InfoPay, {
       amount,
       currency,
@@ -192,6 +196,7 @@ export default class WithdrawModalMultisig extends React.Component {
       txId,
       toAddress: to
     })
+    */
 
     this.setState({
       isShipped: false,
@@ -201,6 +206,10 @@ export default class WithdrawModalMultisig extends React.Component {
     if (onReady instanceof Function) {
       onReady()
     }
+
+    const txInfoUrl = helpers.transactions.getTxRouter('btc', txId)
+    redirectTo(txInfoUrl)
+
     actions.modals.close(name)
   }
 

--- a/shared/helpers/ethToken.js
+++ b/shared/helpers/ethToken.js
@@ -1,5 +1,5 @@
 import actions from 'redux/actions'
-import config from 'app-config'
+import config from './externalConfig'
 import eth from './eth'
 import constants from './constants'
 import BigNumber from 'bignumber.js'

--- a/shared/helpers/getWalletLink.js
+++ b/shared/helpers/getWalletLink.js
@@ -1,0 +1,40 @@
+import getCurrencyKey from './getCurrencyKey'
+import ethToken from './ethToken'
+import actions from 'redux/actions'
+
+
+
+const getWalletLink = (currency, checkAddress) => {
+  let ourWallets = false
+  const isEthToken = ethToken.isEthToken({ name: currency })
+  const prefix = getCurrencyKey(currency)
+
+  if (isEthToken) {
+    ourWallets = actions.eth.getAllMyAddresses()
+  } else {
+    if (actions[prefix]
+      && typeof actions[prefix].getAllMyAddresses === 'function'
+    ) {
+      ourWallets = actions[prefix].getAllMyAddresses()
+    } else {
+      console.warn(`Function getAllMyAddresses not defined (currency ${currency})`)
+    }
+  }
+
+  if (!ourWallets) return false
+
+  const our = checkAddress.filter((address) => ourWallets.includes(address.toLowerCase()))
+
+  if (our.length) {
+    const targetWallet = our[0]
+
+    return (isEthToken) ?
+      `/token/${currency.toUpperCase()}/${targetWallet}`
+      : `/${prefix.toUpperCase()}/${targetWallet}`
+  }
+
+  return false
+}
+
+
+export default getWalletLink

--- a/shared/helpers/index.js
+++ b/shared/helpers/index.js
@@ -33,6 +33,9 @@ import { cacheStorageGet, cacheStorageSet } from './cache'
 
 import apiLooper from './apiLooper'
 
+import getWalletLink from './getWalletLink'
+
+
 
 export default {
   // xlm,
@@ -81,4 +84,6 @@ export {
   cacheStorageSet,
 
   apiLooper,
+
+  getWalletLink,
 }

--- a/shared/helpers/index.js
+++ b/shared/helpers/index.js
@@ -35,6 +35,8 @@ import apiLooper from './apiLooper'
 
 import getWalletLink from './getWalletLink'
 
+import redirectTo from './redirectTo'
+
 
 
 export default {
@@ -86,4 +88,6 @@ export {
   apiLooper,
 
   getWalletLink,
+
+  redirectTo,
 }

--- a/shared/helpers/redirectTo.js
+++ b/shared/helpers/redirectTo.js
@@ -1,0 +1,10 @@
+
+
+const redirectTo = (url) => {
+  if (url) {
+    if (url.substr(0,1) !== `#`) url = `#${url}`
+    window.location.hash = url
+  }
+}
+
+export default redirectTo

--- a/shared/helpers/transactions.js
+++ b/shared/helpers/transactions.js
@@ -2,6 +2,18 @@ import helpers from "helpers";
 import actions from 'redux/actions'
 
 
+const getTxRouter = (currency, txId) => {
+  const prefix = helpers.getCurrencyKey(currency)
+
+  if (actions[prefix]
+    && typeof actions[prefix].getTxRouter === 'function'
+  ) {
+    return actions[prefix].getTxRouter(txId, currency.toLowerCase())
+  } else {
+    console.warn(`Function getTxRouter for ${prefix} not defined (currency: ${currency})`)
+  }
+}
+
 const getLink = (currency, txId) => {
   const prefix = helpers.getCurrencyKey(currency)
 
@@ -38,4 +50,5 @@ const getInfo = (currency, txRaw) => {
 export default {
   getInfo,
   getLink,
+  getTxRouter,
 }

--- a/shared/localisation/_default.json
+++ b/shared/localisation/_default.json
@@ -7702,5 +7702,12 @@
     "files": [
       "shared/components/modals/RegisterSMSProtected/RegisterSMSProtected.js"
     ]
+  },
+  {
+    "id": "ShareModal_LinkCopied",
+    "message": "Link copied",
+    "files": [
+      "shared/components/modals/Share/Share.js"
+    ]
   }
 ]

--- a/shared/localisation/en.json
+++ b/shared/localisation/en.json
@@ -7714,5 +7714,12 @@
     "files": [
       "shared/components/modals/RegisterSMSProtected/RegisterSMSProtected.js"
     ]
+  },
+  {
+    "id": "ShareModal_LinkCopied",
+    "message": "Link copied",
+    "files": [
+      "shared/components/modals/Share/Share.js"
+    ]
   }
 ]

--- a/shared/localisation/ru.json
+++ b/shared/localisation/ru.json
@@ -7722,5 +7722,12 @@
     "files": [
       "shared/components/modals/RegisterSMSProtected/RegisterSMSProtected.js"
     ]
+  },
+  {
+    "id": "ShareModal_LinkCopied",
+    "message": "Ссылка скопирована",
+    "files": [
+      "shared/components/modals/Share/Share.js"
+    ]
   }
 ]

--- a/shared/pages/History/Row/Row.js
+++ b/shared/pages/History/Row/Row.js
@@ -185,8 +185,7 @@ class Row extends React.PureComponent {
       <>
         <tr styleName='historyRow'>
           <td>
-        
-          <div styleName={`${statusStyleAmount} circleIcon`}>
+            <div styleName={`${statusStyleAmount} circleIcon`}>
               <div styleName='arrowWrap'>
                 <Link to={txLink}>
                   <svg width='12' height='15' viewBox='0 0 12 15' fill='none' xmlns='http://www.w3.org/2000/svg'>
@@ -200,28 +199,32 @@ class Row extends React.PureComponent {
               <div>
                 {txType === 'INVOICE' ?
                   <>
-                    <FormattedMessage 
-                      id="RowHistoryInvoce" 
-                      defaultMessage="Инвойс #{number} ({contact})" 
-                      values={{
-                        number: `${invoiceData.id}-${invoiceData.invoiceNumber}`, 
-                        contact: (invoiceData.contact) ? `(${invoiceData.contact})` : ''
-                      }}
-                    />
+                    <Link to={txLink}>
+                      <FormattedMessage 
+                        id="RowHistoryInvoce" 
+                        defaultMessage="Инвойс #{number} ({contact})" 
+                        values={{
+                          number: `${invoiceData.id}-${invoiceData.invoiceNumber}`, 
+                          contact: (invoiceData.contact) ? `(${invoiceData.contact})` : ''
+                        }}
+                      />
+                    </Link>
                     <div styleName={`${invoiceStatusClass} cell`}>
                       {invoiceStatusText}
                     </div>
                   </> :
                   <>
-                    {
-                      direction === 'in'
-                        ? <FormattedMessage id="RowHistory281" defaultMessage="Received" />
-                        : (
-                          direction !== 'self'
-                            ? <FormattedMessage id="RowHistory282" defaultMessage="Sent" />
-                            : <FormattedMessage id="RowHistory283" defaultMessage="Self" />
-                        )
-                    }
+                    <Link to={txLink}>
+                      {
+                        direction === 'in'
+                          ? <FormattedMessage id="RowHistory281" defaultMessage="Received" />
+                          : (
+                            direction !== 'self'
+                              ? <FormattedMessage id="RowHistory282" defaultMessage="Sent" />
+                              : <FormattedMessage id="RowHistory283" defaultMessage="Self" />
+                          )
+                      }
+                    </Link>
                     <div styleName={confirmations > 0 ? 'confirm cell' : 'unconfirmed cell'}>
                       {confirmations > 0 ? confirmations > 6 ?
                         <FormattedMessage id="RowHistory34" defaultMessage="Received" /> :
@@ -231,7 +234,8 @@ class Row extends React.PureComponent {
                     </div>
                     
                     
-                  </>}
+                  </>
+                }
               </div>
               <CommentRow
                 isOpen={isOpen}

--- a/shared/pages/History/Row/Row.scss
+++ b/shared/pages/History/Row/Row.scss
@@ -130,6 +130,10 @@
 .historyInfo {
   margin-left: 50px;
   margin-top: -37px;
+
+  a {
+    color: #212529;
+  }
 }
 
 .info {

--- a/shared/pages/Transaction/Transaction.js
+++ b/shared/pages/Transaction/Transaction.js
@@ -5,6 +5,7 @@ import { constants } from 'helpers'
 import getCurrencyKey from "helpers/getCurrencyKey";
 import { FormattedMessage } from 'react-intl'
 import getWalletLink from 'helpers/getWalletLink'
+import redirectTo from 'helpers/redirectTo'
 
 
 class Transaction extends Component {
@@ -101,7 +102,7 @@ class Transaction extends Component {
           } else wallets.push(walletTwo)
 
           const walletLink = getWalletLink(ticker, wallets)
-          history.push((walletLink) ? walletLink : '/')
+          redirectTo((walletLink) ? walletLink : '/')
         },
         isFetching: true,
         onFetching: (infoModal) => {

--- a/shared/pages/Transaction/Transaction.js
+++ b/shared/pages/Transaction/Transaction.js
@@ -50,6 +50,7 @@ class Transaction extends Component {
       balance:0,
       oldBalance: infoTx.afterBalance,
       confirmed: infoTx.confirmed,
+      sender: infoTx.senderAddress,
       toAddress: infoTx.receiverAddress,
       isFetching: false,
     })

--- a/shared/pages/Transaction/Transaction.js
+++ b/shared/pages/Transaction/Transaction.js
@@ -4,6 +4,7 @@ import actions from 'redux/actions'
 import { constants } from 'helpers'
 import getCurrencyKey from "helpers/getCurrencyKey";
 import { FormattedMessage } from 'react-intl'
+import getWalletLink from 'helpers/getWalletLink'
 
 
 class Transaction extends Component {
@@ -76,19 +77,31 @@ class Transaction extends Component {
 
     this.setState({
       currency,
+      ticker,
       txId,
     }, () => {
       actions.modals.open(constants.modals.InfoPay, {
-        currency,
+        currency: ticker,
         txId,
         onClose: () => {
-          if(history.length > 2 ) {
-            history.goBack()
-            return false;
-          }
+          let {
+            infoTx: {
+              senderAddress: walletOne,
+              receiverAddress: walletTwo,
+            },
+          } = this.state
 
-          history.push('/')
-          return false;
+          const wallets = []
+          if (walletOne instanceof Array) {
+            walletOne.forEach((wallet) => wallets.push(wallet))
+          } else wallets.push(walletOne)
+          
+          if (walletTwo instanceof Array) {
+            walletTwo.forEach((wallet) => wallets.push(wallet))
+          } else wallets.push(walletTwo)
+
+          const walletLink = getWalletLink(ticker, wallets)
+          history.push((walletLink) ? walletLink : '/')
         },
         isFetching: true,
         onFetching: (infoModal) => {

--- a/shared/redux/actions/bch.js
+++ b/shared/redux/actions/bch.js
@@ -68,12 +68,16 @@ const getTx = (txRaw) => {
   return false
 }
 
+const getTxRouter = (txId) => {
+  return `/bch/tx/${txId}`
+}
+
 const getLinkToInfo = (tx) => {
   if(!tx) {
     return
   }
 
-  return `https://www.blockchain.com/ru/btc/tx/${tx}`
+  return `https://www.blockchain.com/ru/bch/tx/${tx}`
 }
 
 const fetchBalance = (address) =>
@@ -221,5 +225,6 @@ export default {
   signMessage,
   getTx,
   getLinkToInfo,
-  getReputation
+  getReputation,
+  getTxRouter,
 }

--- a/shared/redux/actions/btc.js
+++ b/shared/redux/actions/btc.js
@@ -14,6 +14,9 @@ import actions from 'redux/actions'
 import typeforce from "swap.app/util/typeforce"
 import config from 'app-config'
 
+import { localisePrefix } from 'helpers/locale'
+
+
 
 const getRandomMnemonicWords = () => bip39.generateMnemonic()
 const validateMnemonicWords = (mnemonic) => bip39.validateMnemonic(mnemonic)
@@ -243,6 +246,10 @@ const loginWithKeychain = async () => {
 const getTx = (txRaw) => {
 
   return txRaw.getId()
+}
+
+const getTxRouter = (txId) => {
+  return `/btc/tx/${txId}`
 }
 
 const getLinkToInfo = (tx) => {
@@ -578,4 +585,5 @@ export default {
   getAllMyAddresses,
   getDataByAddress,
   getMainPublicKey,
+  getTxRouter,
 }

--- a/shared/redux/actions/eth.js
+++ b/shared/redux/actions/eth.js
@@ -260,6 +260,10 @@ const getTx = (txRaw) => {
   return txRaw.transactionHash
 }
 
+const getTxRouter = (txId) => {
+  return `/eth/tx/${txId}`
+}
+
 const getLinkToInfo = (tx) => {
 
   if(!tx) {
@@ -384,4 +388,5 @@ export default {
   getSweepAddress,
   getAllMyAddresses,
   fetchTxInfo,
+  getTxRouter,
 }

--- a/shared/redux/actions/ltc.js
+++ b/shared/redux/actions/ltc.js
@@ -139,6 +139,10 @@ const getTx = (txRaw) => {
   return txRaw.transactionHash
 }
 
+const getTxRouter = (txId) => {
+  return `/ltc/tx/${txId}`
+}
+
 const getLinkToInfo = (tx) => {
 
   if(!tx) {
@@ -213,5 +217,6 @@ export default {
   fetchTxInfo,
   fetchBalance,
   signMessage,
-  getReputation
+  getReputation,
+  getTxRouter,
 }

--- a/shared/redux/actions/token.js
+++ b/shared/redux/actions/token.js
@@ -209,6 +209,11 @@ const getTx = (txRaw) => {
   return txRaw.transactionHash
 }
 
+const getTxRouter = (txId, currency) => {
+  return `/token/${currency.toUpperCase()}/tx/${txId}`
+}
+
+
 const getLinkToInfo = (tx) => {
 
   if(!tx) {
@@ -366,4 +371,5 @@ export default {
   AddCustomERC20,
   GetCustromERC20,
   fetchTxInfo,
+  getTxRouter,
 }

--- a/shared/routes/index.js
+++ b/shared/routes/index.js
@@ -31,7 +31,7 @@ const routes = (
     <Switch>
       <Route path={`${localisePrefix}${links.swap}/:buy-:sell/:orderId`} component={SwapComponent} />
       
-      <Route path={`${localisePrefix}/:ticker(btc|eth)/tx/:tx?`} component={Transaction} />
+      <Route path={`${localisePrefix}/:ticker(btc|eth|ltc)/tx/:tx?`} component={Transaction} />
       <Route path={`${localisePrefix}/:token(token)/:ticker/tx/:tx?`} component={Transaction} />
       <Route path={`${localisePrefix}/:ticker(btc|eth|ltc)/:address`} component={CurrencyWallet} />
       <Route path={`${localisePrefix}/:token(token)/:ticker/:address`} component={CurrencyWallet} />


### PR DESCRIPTION
# Pull request template

## Checklist

<!-- You have to tick all the boxes -->

- [x] I have read the [CONTRIBUTING](https://github.com/swaponline/swap.react/wiki/CONTRIBUTING) guide
- [x] branch rebased on `master`
- [x] styleguide check `npm run validate`
- [x] good naming
- [x] keep simple
- [ ] video or screenshot attached
- [ ] testing instruction attached
- [x] check your PR once again


### Description

Решение ишью https://github.com/swaponline/MultiCurrencyWallet/issues/2595
Фиксы и улучшения с оптимизацией (по ходу решения ишью)

При закрытии информации о Tx (Нажатии на крестик), определяются адреса получателя и отправителя
Если среди этих адресов есть наш (первое совпадение), производит редирект на него (/btc/walletaddress ....)
Если среди адресов нет нашего - редирект на главную

В связи с этим, во время теста (когда перекидываешь монеты с btc на 2fa или мультисиг), при просмотре таких транзакций может открыть другой кошелек (не тот, с которого перешли на информацию об транзакции)



### Video or screenshot

<!-- Paste video or screenshots -->




### What and how to test

<!-- What reviewer should do? -->





