### PR TITLE
входящий запрос только для второго подписанта

### DIFF
--- a/shared/pages/Wallet/components/WallerSlider/index.js
+++ b/shared/pages/Wallet/components/WallerSlider/index.js
@@ -142,7 +142,7 @@ export default class WallerSlider extends Component {
                     className="notifyIncomeRequest"
                     firstBtn={needSignMultisig}
                     widthIcon="80"
-                    background="1f2d48"
+                    background="FFFF33"
                     descr={needSignMultisig}
                     logDescr={`Click on btc ms notify block (banner)`}
                     firstFunc={this.handleGoToMultisigRequest}

--- a/shared/redux/actions/multisigTx.js
+++ b/shared/redux/actions/multisigTx.js
@@ -115,7 +115,7 @@ const fetch = (address) => {
         }
 
         // @ToDo - (draft) use api request for fetch status of address list
-        if (status === 'pending') {
+        if (status === 'pending' && holderKey !== item.holder) {
           firstPending = firstPending || {
             address,
             item,


### PR DESCRIPTION
# Pull request template

## Checklist

<!-- You have to tick all the boxes -->

- [x] I have read the [CONTRIBUTING](https://github.com/swaponline/swap.react/wiki/CONTRIBUTING) guide
- [x] branch rebased on `master`
- [x] styleguide check `npm run validate`
- [x] good naming
- [x] keep simple
- [ ] video or screenshot attached
- [ ] testing instruction attached
- [x] check your PR once again


### Description

Фикс. Информер о не подписанных транзакциях выводился для двух сторон (тому, кому нужно подписать, и у того, кто инициализировал списание)


### Video or screenshot

![image](https://user-images.githubusercontent.com/1880211/82726823-4b242c00-9cef-11ea-92c1-d5c9af60be2c.png)




### What and how to test

<!-- What reviewer should do? -->

To test it locally run ```git fetch && fit checkout twelveWordsCreateBug``` where twelveWordsCreateBug is a name of this branch (see under title) OR ```git fetch origin refs/pull/2590/merge:pr2590 && git checkout pr2590``` where 2590 is number of this pull request

```npm i && npm run build:mainnet``` then run MultiCurrencyWallet/build.mainnet/index.html in browse

