### PR TITLE
Newui - don't show banners when window.bannersOnMainPage = ""

### DIFF
--- a/shared/pages/Wallet/components/WallerSlider/index.js
+++ b/shared/pages/Wallet/components/WallerSlider/index.js
@@ -74,12 +74,12 @@ export default class WallerSlider extends Component {
 
   getBanners = () => {
     if (window
-      && window.bannersOnMainPage
-      && window.bannersOnMainPage.length
+      && window.bannersOnMainPage !== undefined
     ) {
       // Используем банеры, которые были определены в index.html (используется в виджете вордпресса)
+      const widgetBanners = (window.bannersOnMainPage.length) ? window.bannersOnMainPage : []
       this.setState(() => ({
-        banners: this.processItezBanner(window.bannersOnMainPage).filter(el => el && el.length),
+        banners: this.processItezBanner(widgetBanners).filter(el => el && el.length),
         isFetching: true,
       }), () => this.initBanners())
     } else {
@@ -150,6 +150,7 @@ export default class WallerSlider extends Component {
         }}
       />
     )
+
     return (window.location.hash !== linksManager.hashHome) ? null : (
       <div className="data-tut-banners">
         <h3 className={styles.bannersHeading}>
@@ -186,7 +187,7 @@ export default class WallerSlider extends Component {
                   />
                 </div>
               )}
-              {banners.length && banners.map(banner => (
+              {banners && banners.length > 0 && banners.map(banner => (
                 <div key={banner[0]} className="swiper-slide">
                   <NotifyBlock background={`${banner[3]}`} descr={banner[2]} link={banner[4]} icon={banner[5]} />
                 </div>


### PR DESCRIPTION
# Pull request template

## Checklist

<!-- You have to tick all the boxes -->

- [x] I have read the [CONTRIBUTING](https://github.com/swaponline/swap.react/wiki/CONTRIBUTING) guide
- [x] branch rebased on `master`
- [x] styleguide check `npm run validate`
- [x] good naming
- [x] keep simple
- [x] video or screenshot attached
- [ ] testing instruction attached
- [x] check your PR once again


### Description

Решение ишью https://github.com/swaponline/MultiCurrencyWallet/issues/2849




### Video or screenshot
window.bannersOnMainPage = ""
![image](https://user-images.githubusercontent.com/1880211/84195923-0c8cc080-aaa8-11ea-98aa-8dee5b2ebe4f.png)


window.bannersOnMainPage =  [ ..... ]
![image](https://user-images.githubusercontent.com/1880211/84195967-1f9f9080-aaa8-11ea-89c6-af0fb28d0ff9.png)

window.bannersOnMainPage = undefined (swaponline билд)
![image](https://user-images.githubusercontent.com/1880211/84196042-4067e600-aaa8-11ea-8b30-88ad399b5786.png)




### What and how to test

<!-- What reviewer should do? -->

To test it locally run ```git fetch && fit checkout twelveWordsCreateBug``` where twelveWordsCreateBug is a name of this branch (see under title) OR ```PRID=2812; git fetch origin refs/pull/$PRID/merge:pr$PRID && git checkout pr$PRID``` where PRID is number of this pull request

```npm i && npm run build:mainnet``` then run MultiCurrencyWallet/build.mainnet/index.html in browse

