### PR TITLE
Issue2918 - external config - option for hide 'copy private key' menu item

### DIFF
--- a/externalConfigs/testnet-default.js
+++ b/externalConfigs/testnet-default.js
@@ -45,6 +45,7 @@ window.buildOptions = {
   curEnabled: false,
   showWalletBanners: true, // Allow to see banners
   invoiceEnabled: true, // Allow create invoices
+  hideShowPrivateKey: true, // Hide 'Copy Private Key' Menu item, default false, inited also from window.SWAP_HIDE_PRIVATEKEY
 //  fee: { btc .... }, // Can be inited from window.widgetERC20Comisions
 }
 */

--- a/externalConfigs/testnet-default.js
+++ b/externalConfigs/testnet-default.js
@@ -45,7 +45,7 @@ window.buildOptions = {
   curEnabled: false,
   showWalletBanners: true, // Allow to see banners
   invoiceEnabled: true, // Allow create invoices
-  hideShowPrivateKey: true, // Hide 'Copy Private Key' Menu item, default false, inited also from window.SWAP_HIDE_PRIVATEKEY
+  hideShowPrivateKey: true, // Hide 'Copy Private Key' Menu item, default false, inited also from window.SWAP_HIDE_EXPORT_PRIVATEKEY
 //  fee: { btc .... }, // Can be inited from window.widgetERC20Comisions
 }
 */

--- a/shared/helpers/externalConfig.js
+++ b/shared/helpers/externalConfig.js
@@ -55,9 +55,9 @@ const externalConfig = () => {
   }
 
   if (window
-    && window.SWAP_HIDE_PRIVATEKEY !== undefined
+    && window.SWAP_HIDE_EXPORT_PRIVATEKEY !== undefined
   ) {
-    config.opts.hideShowPrivateKey = window.SWAP_HIDE_PRIVATEKEY
+    config.opts.hideShowPrivateKey = window.SWAP_HIDE_EXPORT_PRIVATEKEY
   }
 
   if (window

--- a/shared/helpers/externalConfig.js
+++ b/shared/helpers/externalConfig.js
@@ -37,6 +37,7 @@ const externalConfig = () => {
     showWalletBanners: false,
     showHowItsWork: false,
     fee: {},
+    hideShowPrivateKey: false,
   }
 
   if (window
@@ -51,6 +52,12 @@ const externalConfig = () => {
     && Object.keys(window.buildOptions).length
   ) {
     config.opts = { ...config.opts, ...window.buildOptions }
+  }
+
+  if (window
+    && window.SWAP_HIDE_PRIVATEKEY !== undefined
+  ) {
+    config.opts.hideShowPrivateKey = window.SWAP_HIDE_PRIVATEKEY
   }
 
   if (window

--- a/shared/pages/Wallet/Row/Row.js
+++ b/shared/pages/Wallet/Row/Row.js
@@ -641,7 +641,7 @@ export default class Row extends Component {
         action: this.copy,
         disabled: false,
       },
-      {
+      !config.opts.hideShowPrivateKey && {
         id: 1012,
         title: (
           <FormattedMessage


### PR DESCRIPTION
# Pull request template

## Checklist

<!-- You have to tick all the boxes -->

- [ ] I have read the [CONTRIBUTING](https://github.com/swaponline/swap.react/wiki/CONTRIBUTING) guide
- [ ] branch rebased on `master`
- [ ] styleguide check `npm run validate`
- [ ] good naming
- [ ] keep simple
- [ ] video or screenshot attached
- [ ] testing instruction attached
- [ ] check your PR once again


### Description

Решение ишью https://github.com/swaponline/MultiCurrencyWallet/issues/2918 https://github.com/swaponline/MultiCurrencyWallet/issues/2914

добавил опцию config.opts.hideShowPrivateKey
так-же инициализируется из window.SWAP_HIDE_PRIVATEKEY
по умолчанию false




### Video or screenshot

<!-- Paste video or screenshots -->




### What and how to test

<!-- What reviewer should do? -->

To test it locally run ```git fetch && fit checkout twelveWordsCreateBug``` where twelveWordsCreateBug is a name of this branch (see under title) OR ```PRID=2812; git fetch origin refs/pull/$PRID/merge:pr$PRID && git checkout pr$PRID``` where PRID is number of this pull request

```npm i && npm run build:mainnet``` then run MultiCurrencyWallet/build.mainnet/index.html in browse

