### PR TITLE
Issue3071 - send/btc-sms:"SMS code not valid" doesn't showing

### DIFF
--- a/shared/components/modals/WithdrawBtcSms/WithdrawBtcSms.scss
+++ b/shared/components/modals/WithdrawBtcSms/WithdrawBtcSms.scss
@@ -8,6 +8,9 @@
   padding-top: 10px;
   padding-bottom: 10px;
   font-size: 14px;
+  &.hasError {
+    color: $color-f-error;
+  }
 }
 
 .confirmSmsCode {

--- a/shared/localisation/_default.json
+++ b/shared/localisation/_default.json
@@ -7342,5 +7342,26 @@
     "files": [
       "shared/pages/Wallet/Row/Row.js"
     ]
+  },
+  {
+    "id": "WithdrawSMS_NotValidSmsCode",
+    "message": "Вы ввели не верный проверочный код",
+    "files": [
+      "shared/components/modals/WithdrawBtcSms/WithdrawBtcSms.js"
+    ]
+  },
+  {
+    "id": "WithdrawSMS_SmsConfirming",
+    "message": "Подтверждение транзакции",
+    "files": [
+      "shared/components/modals/WithdrawBtcSms/WithdrawBtcSms.js"
+    ]
+  },
+  {
+    "id": "WithdrawSMS_UnknownError",
+    "message": "Не известная ошибка. Попробуйте позже или используйте секретную фразу",
+    "files": [
+      "shared/components/modals/WithdrawBtcSms/WithdrawBtcSms.js"
+    ]
   }
 ]

--- a/shared/localisation/en.json
+++ b/shared/localisation/en.json
@@ -7366,5 +7366,26 @@
     "files": [
       "shared/pages/Wallet/Row/Row.js"
     ]
+  },
+  {
+    "id": "WithdrawSMS_NotValidSmsCode",
+    "message": "Invalid code number",
+    "files": [
+      "shared/components/modals/WithdrawBtcSms/WithdrawBtcSms.js"
+    ]
+  },
+  {
+    "id": "WithdrawSMS_SmsConfirming",
+    "message": "Confirming transaction",
+    "files": [
+      "shared/components/modals/WithdrawBtcSms/WithdrawBtcSms.js"
+    ]
+  },
+  {
+    "id": "WithdrawSMS_UnknownError",
+    "message": "Unknown error. Try again or use a passphrase",
+    "files": [
+      "shared/components/modals/WithdrawBtcSms/WithdrawBtcSms.js"
+    ]
   }
 ]

--- a/shared/localisation/ru.json
+++ b/shared/localisation/ru.json
@@ -7438,5 +7438,26 @@
     "files": [
       "shared/pages/Wallet/Row/Row.js"
     ]
+  },
+  {
+    "id": "WithdrawSMS_NotValidSmsCode",
+    "message": "Вы ввели не верный проверочный код",
+    "files": [
+      "shared/components/modals/WithdrawBtcSms/WithdrawBtcSms.js"
+    ]
+  },
+  {
+    "id": "WithdrawSMS_SmsConfirming",
+    "message": "Подтверждение транзакции",
+    "files": [
+      "shared/components/modals/WithdrawBtcSms/WithdrawBtcSms.js"
+    ]
+  },
+  {
+    "id": "WithdrawSMS_UnknownError",
+    "message": "Не известная ошибка. Попробуйте позже или используйте секретную фразу",
+    "files": [
+      "shared/components/modals/WithdrawBtcSms/WithdrawBtcSms.js"
+    ]
   }
 ]

--- a/shared/pages/Wallet/Wallet.scss
+++ b/shared/pages/Wallet/Wallet.scss
@@ -80,6 +80,8 @@
     color: #d20404;
     cursor: pointer;
     text-decoration: underline;
+    padding-left: 10px;
+    padding-right: 10px;
   }
 }
 


### PR DESCRIPTION
# Pull request template

## Checklist

<!-- You have to tick all the boxes -->

- [x] I have read the [CONTRIBUTING](https://github.com/swaponline/swap.react/wiki/CONTRIBUTING) guide
- [x] branch rebased on `master`
- [x] styleguide check `npm run validate`
- [x] good naming
- [x] keep simple
- [ ] video or screenshot attached
- [ ] testing instruction attached
- [x] check your PR once again


### Description
https://github.com/swaponline/MultiCurrencyWallet/issues/3071
<!-- Include issue number and motivation for these code changes -->




### Video or screenshot

<!-- Paste video or screenshots -->




### What and how to test

<!-- What reviewer should do? -->

To test it locally run ```git fetch && fit checkout twelveWordsCreateBug``` where twelveWordsCreateBug is a name of this branch (see under title) OR ```PRID=2812; git fetch origin refs/pull/$PRID/merge:pr$PRID && git checkout pr$PRID``` where PRID is number of this pull request

```npm i && npm run build:mainnet``` then run MultiCurrencyWallet/build.mainnet/index.html in browse

