### PR TITLE
wp - skip tour if user restored

### DIFF
--- a/src/front/shared/plugins/backupUserData.js
+++ b/src/front/shared/plugins/backupUserData.js
@@ -195,11 +195,17 @@ const backupUserData = {
             set(`ethMnemonic`, data.ethMnemonic)
             set(`twentywords`, data.twentywords)
 
+            // set other params to true (user has on tour and other pages)
             localStorage.setItem(constants.localStorage.hiddenCoinsList, data.hiddenCoinsList)
-            localStorage.setItem(constants.localStorage.isWalletCreate, data.isWalletCreate)
+            localStorage.setItem(constants.localStorage.isWalletCreate, true)
+            localStorage.setItem(constants.localStorage.wasOnExchange, true)
+            localStorage.setItem(constants.localStorage.wasOnWidgetWallet, true)
+            localStorage.setItem(constants.localStorage.wasCautionPassed, true)
+            localStorage.setItem(constants.localStorage.wasOnWallet, true)
             localStorage.setItem(constants.localStorage.didProtectedBtcCreated, data.didProtectedBtcCreated)
             localStorage.setItem(constants.localStorage.didPinBtcCreated, data.didPinBtcCreated)
             localStorage.setItem(lsCurrentUser, window.WPuserUid)
+
 
             resolve(true)
           } else {


### PR DESCRIPTION
## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/swaponline/swap.react/wiki/CONTRIBUTING) guide
- [x] Styleguide check `npm run validate`
- [x] Good naming, keep simple
- [x] Tested desktop/mobile
- [x] Tested bright/dark
- [x] Tested en/ru
- [x] Affects money; I checked the functionality once again
- [x] I checked the PR once again

### Original issue
https://github.com/swaponline/MultiCurrencyWallet/issues/3409

### Video / screenshot proof
<!-- You can use Ctrl+V -->
