### PR TITLE
Fix spelling error 'pivate'->'private' (#3446)

### DIFF
--- a/src/front/shared/components/modals/PrivateKeysModal/PrivateKeysModal.js
+++ b/src/front/shared/components/modals/PrivateKeysModal/PrivateKeysModal.js
@@ -49,7 +49,7 @@ export default class PrivateKeysModal extends React.PureComponent {
           <p styleName="text">
             <FormattedMessage
               id="privateKeyCurrency"
-              defaultMessage="Your {cur} pivate key"
+              defaultMessage="Your {cur} private key"
               values={{
                 cur: fullName,
               }}

--- a/src/front/shared/localisation/_default.json
+++ b/src/front/shared/localisation/_default.json
@@ -7114,7 +7114,7 @@
   },
   {
     "id": "privateKeyCurrency",
-    "message": "Your {cur} pivate key",
+    "message": "Your {cur} private key",
     "files": [
       "shared/components/modals/PrivateKeysModal/PrivateKeysModal.js"
     ]

--- a/src/front/shared/localisation/en.json
+++ b/src/front/shared/localisation/en.json
@@ -7159,7 +7159,7 @@
   },
   {
     "id": "privateKeyCurrency",
-    "message": "Your {cur} pivate key",
+    "message": "Your {cur} private key",
     "files": [
       "shared/components/modals/PrivateKeysModal/PrivateKeysModal.js"
     ]

--- a/src/front/shared/localisation/nl.json
+++ b/src/front/shared/localisation/nl.json
@@ -7147,7 +7147,7 @@
   },
   {
     "id": "privateKeyCurrency",
-    "message": "Your {cur} pivate key",
+    "message": "Uw {cur} privésleutel",
     "files": [
       "shared/components/modals/PrivateKeysModal/PrivateKeysModal.js"
     ]

--- a/src/front/shared/localisation/ru.json
+++ b/src/front/shared/localisation/ru.json
@@ -7231,7 +7231,7 @@
   },
   {
     "id": "privateKeyCurrency",
-    "message": "Your {cur} pivate key",
+    "message": "Ваш приватный ключ {cur}",
     "files": [
       "shared/components/modals/PrivateKeysModal/PrivateKeysModal.js"
     ]


### PR DESCRIPTION
## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/swaponline/swap.react/wiki/CONTRIBUTING) guide
- [x] Styleguide check `npm run validate`
- [x] Good naming, keep simple
- [ ] Tested desktop/mobile
- [ ] Tested bright/dark
- [ ] Tested en/ru
- [ ] Affects money; I checked the functionality once again
- [x] I checked the PR once again

### Original issue
<!-- Type number -->
#3446

