### PR TITLE
FIrst screen: Change handler on restore link

### DIFF
--- a/src/front/client/index.html
+++ b/src/front/client/index.html
@@ -826,7 +826,9 @@
 
         // Restore wallet
         btnRestoryWallet.addEventListener('click', () => {
-          redirectionTo('#/createWallet')
+          setCookie('swapDisalbeStarter', 'true', {
+            expires: SEC_IN_YEAR * 5,
+          });
         })
 
         function redirectionTo(urlPath) {

--- a/src/front/shared/components/modal/Modal/Modal.js
+++ b/src/front/shared/components/modal/Modal/Modal.js
@@ -26,7 +26,7 @@ export default class Modal extends Component {
 
   static propTypes = {
     children: PropTypes.node,
-    name: PropTypes.string.isRequired,
+    name: PropTypes.string,
     title: PropTypes.any,
     showCloseButton: PropTypes.bool,
     data: PropTypes.object,

--- a/src/front/shared/pages/CreateWallet/CreateWallet.js
+++ b/src/front/shared/pages/CreateWallet/CreateWallet.js
@@ -334,10 +334,16 @@ const CreateWallet = (props) => {
     // Link from index.html (first screen)
     const starterModalRestoreWallet = document.getElementById('starter-modal__link-restore-wallet')
     if (starterModalRestoreWallet) {
-      starterModalRestoreWallet.addEventListener('click', handleRestoreMnemonic)
+      starterModalRestoreWallet.addEventListener('click', redirectToRestoreWallet)
 
       return () => {
-        starterModalRestoreWallet.removeEventListener('click', handleRestoreMnemonic)
+        starterModalRestoreWallet.removeEventListener('click', redirectToRestoreWallet)
+      }
+
+      function redirectToRestoreWallet() {
+        document.location.href = '#/restoreWallet'
+        handleRestoreMnemonic()
+        document.getElementById('starter-modal').classList.add('d-none')
       }
     }
   }, [])


### PR DESCRIPTION
## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/swaponline/swap.react/wiki/CONTRIBUTING) guide
- [x] Good naming, keep simple
- [x] Tested desktop/mobile
- [ ] Tested bright/dark
- [ ] Tested en/ru
- [x] Affects money; I checked the functionality once again
- [x] I checked the PR once again

Сheck that the link always throws in restore wallet

![image](https://user-images.githubusercontent.com/61930014/98206754-6ae59e80-1f75-11eb-8d8b-37f844b59cde.png)

