### PR TITLE
Wallet and Exchange: fix redirect to history and possibility to create an offer

### DIFF
--- a/src/front/shared/pages/Exchange/Exchange.js
+++ b/src/front/shared/pages/Exchange/Exchange.js
@@ -246,6 +246,7 @@ export default class Exchange extends Component {
       estimatedFeeValues: {},
       isWaitForPeerAnswer: false,
       desclineOrders: [],
+      balanceOnWalletsIsOk: false,
     };
 
     constants.coinsWithDynamicFee.forEach(
@@ -1119,6 +1120,18 @@ export default class Exchange extends Component {
     });
   };
 
+  componentDidMount() {
+    const walletsArray = actions.core.getWallets()
+
+    for (let wallet of walletsArray) {
+      if (wallet.balance > 0) {
+        this.setState({
+          balanceOnWalletsIsOk: true
+        })
+        break
+      } 
+    }
+  }
 
   render() {
     const {
@@ -1157,6 +1170,7 @@ export default class Exchange extends Component {
       isWaitForPeerAnswer,
       desclineOrders,
       isDeclinedOffer,
+      balanceOnWalletsIsOk,
     } = this.state
 
     if (redirectToSwap) {
@@ -1550,12 +1564,12 @@ export default class Exchange extends Component {
             <>
               <Button
                 id="createOrderReactTooltipMessageForUser"
-                styleName={`button link-like ${balance > 0 ? '' : 'noMany'}`}
-                onClick={ balance > 0 ? this.createOffer : null}
+                styleName={`button link-like ${balanceOnWalletsIsOk ? '' : 'noMany'}`}
+                onClick={balanceOnWalletsIsOk ? this.createOffer : null}
               >
                 <FormattedMessage id="orders128" defaultMessage="Create offer" />
               </Button>
-              { balance > 0
+              {balanceOnWalletsIsOk
                 ? (
                   <ReactTooltip id="createOrderReactTooltipMessageForUser" effect="solid" type="dark" place="bottom">
                     <FormattedMessage

--- a/src/front/shared/pages/Wallet/Row/Row.js
+++ b/src/front/shared/pages/Wallet/Row/Row.js
@@ -891,9 +891,8 @@ export default class Row extends Component {
       }
     }
 
-    const addressIsOk = !(this.props.itemData.isMetamask 
-                        && ! this.props.itemData.isConnected)
-                        && mnemonicSaved
+    const metamaskIsOk = this.props.itemData.isMetamask && this.props.itemData.isConnected
+    const addressIsOk = !metamaskIsOk && mnemonicSaved
 
     return (
       <tr>
@@ -904,11 +903,11 @@ export default class Row extends Component {
             <div styleName="assetsTableInfo">
               <div styleName="nameRow">
                 <a /* Redirect to history if connect wallet */
-                  onClick={ addressIsOk ? this.goToCurrencyHistory : () => null }
+                  onClick={ addressIsOk || metamaskIsOk ? this.goToCurrencyHistory : () => null }
                   styleName={`${
                     addressIsOk && isMobile
                       ? 'linkToHistory mobile'
-                      : addressIsOk 
+                      : addressIsOk || metamaskIsOk
                         ? 'linkToHistory desktop'
                         : ''
                   }`}


### PR DESCRIPTION
## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/swaponline/swap.react/wiki/CONTRIBUTING) guide
- [x] Good naming, keep simple
- [x] Tested desktop/mobile
- [ ] Tested bright/dark
- [ ] Tested en/ru
- [x] Affects money; I checked the functionality once again
- [x] I checked the PR once again

### Original issue
#3538

Теперь, если на аккаунте только что создан пустой кошелек и фраза не сохранена, но подключены сторонние кошельки, можно создавать предложения и переходить в историю сторонних кошельков
