### PR TITLE
Add run upload-artifact action if tests failure

### DIFF
--- a/.github/workflows/needsReviewTesting.yml
+++ b/.github/workflows/needsReviewTesting.yml
@@ -32,9 +32,15 @@ jobs:
         npm run test:e2e_swap:actions
 
     - uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: failure-screenshots
+        path: path/to/artifact/
+    - uses: actions/upload-artifact@v2
       with:
         name: screenshots
         path: ./tests/e2e/screenshots
+        if-no-files-found: ignore
 
       env:
         CI: true

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -30,9 +30,15 @@ jobs:
         mkdir ./tests/e2e/screenshots
         npm run test:e2e:actions
     - uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: failure-screenshots
+        path: path/to/artifact/
+    - uses: actions/upload-artifact@v2
       with:
         name: screenshots
         path: ./tests/e2e/screenshots
+        if-no-files-found: ignore
     - name: bot test
       run: |
         npm run bot:test


### PR DESCRIPTION
## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/swaponline/MultiCurrencyWallet/blob/master/docs/CONTRIBUTING.md) guide
- [ ] Good naming (as clear and simple as possible)
- [ ] Correct behavior if external API endpoints are down, return 404, 504 (or no answer), 401 errors (ddos simulation)
- [ ] I tested desktop/mobile resolution
- [ ] I tested light/dark theme
- [ ] I tested different languages
- [ ] I checked the functionality once again (**AFFECT MONEY**)
- [ ] I checked the **PR** once again

### Original issue
<!-- Type number -->
#4466

### Video / screenshot proof
<!-- You can use Ctrl+V -->
