### PR TITLE
hide theme switcher if theme locked

### DIFF
--- a/src/front/shared/components/Header/Header.tsx
+++ b/src/front/shared/components/Header/Header.tsx
@@ -358,8 +358,10 @@ class Header extends Component<any, any> {
     feedback.theme.switched(wasDark ? 'bright' : 'dark')
     if (wasDark) {
       localStorage.removeItem(constants.localStorage.isDark)
+      localStorage.setItem(constants.localStorage.isLight, 'true')
     } else {
       localStorage.setItem(constants.localStorage.isDark, 'true')
+      localStorage.removeItem(constants.localStorage.isLight)
     }
     window.location.reload()
   }
@@ -439,7 +441,9 @@ class Header extends Component<any, any> {
           <Logo />
         </div>
         <div styleName="rightArea">
-          <ThemeSwitcher themeSwapAnimation={themeSwapAnimation} onClick={this.handleSetDark} />
+          {window.WPSO_selected_theme !== 'only_light' && window.WPSO_selected_theme !== 'only_dark' && (
+            <ThemeSwitcher themeSwapAnimation={themeSwapAnimation} onClick={this.handleSetDark} />
+          )}
 
           {isLogoutPossible && ( // some wordpress plugin cases
             <div styleName={`logoutWrapper ${isDark ? 'dark' : ''}`} onClick={this.handleLogout}>

--- a/src/front/shared/helpers/constants/localStorage.ts
+++ b/src/front/shared/helpers/constants/localStorage.ts
@@ -31,6 +31,7 @@ export default {
   invoicesEnabled: `${process.env.ENTRY}:invoicesEnabled`,
   wasOnWidgetWallet: 'wasOnWidgetWallet',
   isDark: 'isDark',
+  isLight: 'isLight',
   testnetSkipPKCheck: 'testnetSkipPKCheck',
   prevWPUser: 'wp_widget_prev_userid',
   exchangeSettings: 'exchangeSettings',


### PR DESCRIPTION
## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/swaponline/MultiCurrencyWallet/blob/master/docs/CONTRIBUTING.md) guide
- [ ] Good naming (as clear and simple as possible)
- [ ] Correct behavior if external API endpoints are down, return 404, 504 (or no answer), 401 errors (ddos simulation)
- [ ] I tested desktop/mobile resolution
- [ ] I tested light/dark theme
- [ ] I tested different languages
- [ ] I checked the functionality once again (**AFFECT MONEY**)
- [ ] I checked work on the Testnet
- [ ] I checked work on the Mainnet
- [ ] I checked the **PR** once again

### Original issue
<!-- Type number -->
https://github.com/swaponline/MultiCurrencyWallet/issues/3988

### Video / screenshot proof
<!-- You can use Ctrl+V -->
![image](https://user-images.githubusercontent.com/1880211/121737789-ffaf0c80-cb01-11eb-8299-d947efd8e918.png)
