### PR TITLE
Wallet: allow users to send other assets if some of them have problem with API

### DIFF
--- a/src/front/shared/components/modals/WithdrawModal/components/CurrencyList/index.tsx
+++ b/src/front/shared/components/modals/WithdrawModal/components/CurrencyList/index.tsx
@@ -127,7 +127,7 @@ export default class CurrencyList extends Component<any, any> {
               return (
                 <div id={itemId} key={index}
                   styleName={cx('customSelectListItem customSelectValue', {
-                    disabled: item.balance === 0,
+                    disabled: !item.balance || item.balanceError,
                   })}
                   onClick={() => this.openModal({ target: item })}
                 >


### PR DESCRIPTION
## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/swaponline/MultiCurrencyWallet/blob/master/docs/CONTRIBUTING.md) guide
- [ ] Good naming (as clear and simple as possible)
- [ ] Correct behavior if external API endpoints are down, return 404, 504 (or no answer), 401 errors (ddos simulation)
- [ ] I tested desktop/mobile resolution
- [ ] I tested light/dark theme
- [ ] I tested different languages
- [ ] I checked the functionality once again (**AFFECT MONEY**)
- [x] I checked the work on the Testnet
- [ ] I checked the work on the Mainnet
- [ ] I checked the work in the plugin
- [x] I checked the **PR** once again

### Video / screenshot proof

#### Before
![before](https://user-images.githubusercontent.com/61930014/124751846-b8435280-deec-11eb-85ef-2ac58fd4119b.png)

#### After
![after](https://user-images.githubusercontent.com/61930014/124751871-bf6a6080-deec-11eb-8d11-dd489f98668f.png)
