### PR TITLE
Exchange: add setState from and to addresses when set up get and have values

### DIFF
--- a/src/front/shared/pages/Exchange/Exchange.tsx
+++ b/src/front/shared/pages/Exchange/Exchange.tsx
@@ -322,12 +322,6 @@ class Exchange extends PureComponent<ExchangeProps, ExchangeState> {
         : false
 
     switch (type) {
-      case AddressType.Internal:
-        return {
-          type: AddressType.Internal,
-          currency,
-          value: wallet ? wallet.address : '',
-        }
       case AddressType.Metamask:
         return {
           type: AddressType.Metamask,
@@ -340,11 +334,12 @@ class Exchange extends PureComponent<ExchangeProps, ExchangeState> {
           currency,
           value: ``,
         }
-    }
-    return {
-      type: AddressType.Internal,
-      currency,
-      value: wallet ? wallet.address : '',
+      default:
+        return {
+          type: AddressType.Internal,
+          currency,
+          value: wallet ? wallet.address : '',
+        }
     }
   }
 

--- a/src/front/shared/pages/Exchange/Exchange.tsx
+++ b/src/front/shared/pages/Exchange/Exchange.tsx
@@ -227,8 +227,12 @@ class Exchange extends PureComponent<ExchangeProps, ExchangeState> {
       }
     }
 
-    const haveType = this.getDefaultWalletType(haveCurrency.toUpperCase())
-    const getType = this.getDefaultWalletType(getCurrency.toUpperCase())
+    const {
+      haveType,
+      fromAddress,
+      getType,
+      toAddress,
+    } = this.getAddressesDataByCurrencies({haveCurrency, getCurrency})
 
     this.state = {
       isTokenSell: erc20Like.isToken({ name: haveCurrency }),
@@ -261,10 +265,8 @@ class Exchange extends PureComponent<ExchangeProps, ExchangeState> {
       pairFees: false,
       balances: false,
       haveBalance: false,
-      //@ts-ignore: strictNullChecks
-      fromAddress: this.makeAddressObject(haveType, haveCurrency.toUpperCase()),
-      //@ts-ignore: strictNullChecks
-      toAddress: this.makeAddressObject(getType, getCurrency.toUpperCase()),
+      fromAddress,
+      toAddress,
       isTurbo: false,
       redirectToSwap: null,
       isPending: true,
@@ -291,6 +293,23 @@ class Exchange extends PureComponent<ExchangeProps, ExchangeState> {
       constants.notifications.ErrorNotification,
       { error: error.message }
     )
+  }
+
+  getAddressesDataByCurrencies(params) {
+    const { haveCurrency, getCurrency } = params
+
+    const haveType = this.getDefaultWalletType(haveCurrency.toUpperCase())
+    const getType = this.getDefaultWalletType(getCurrency.toUpperCase())
+
+    const fromAddress = this.makeAddressObject(haveType, haveCurrency.toUpperCase())
+    const toAddress = this.makeAddressObject(getType, getCurrency.toUpperCase())
+
+    return {
+      haveType,
+      fromAddress,
+      getType,
+      toAddress,
+    }
   }
 
   makeAddressObject(type, currency) {
@@ -322,7 +341,11 @@ class Exchange extends PureComponent<ExchangeProps, ExchangeState> {
           value: ``,
         }
     }
-    return null
+    return {
+      type: AddressType.Internal,
+      currency,
+      value: wallet ? wallet.address : '',
+    }
   }
 
   getExchangeSettingsFromLocalStorage() {
@@ -1302,12 +1325,21 @@ class Exchange extends PureComponent<ExchangeProps, ExchangeState> {
     if (value === haveCurrency) {
       this.flipCurrency()
     } else {
+      const {
+        haveType,
+        fromAddress,
+        getType,
+        toAddress,
+      } = this.getAddressesDataByCurrencies({haveCurrency, getCurrency: value})
+
       this.setState(
         {
           getCurrency: value,
-          getType: this.getDefaultWalletType(value.toUpperCase()),
+          getType,
+          toAddress,
           haveCurrency,
-          haveType: this.getDefaultWalletType(haveCurrency.toUpperCase()),
+          haveType,
+          fromAddress,
           pairFees: false,
         },
         () => {
@@ -1331,12 +1363,21 @@ class Exchange extends PureComponent<ExchangeProps, ExchangeState> {
     if (value === getCurrency) {
       this.flipCurrency()
     } else {
+      const {
+        haveType,
+        fromAddress,
+        getType,
+        toAddress,
+      } = this.getAddressesDataByCurrencies({haveCurrency: value, getCurrency})
+
       this.setState(
         {
           haveCurrency: value,
-          haveType: this.getDefaultWalletType(value.toUpperCase()),
+          haveType,
+          fromAddress,
           getCurrency,
-          getType: this.getDefaultWalletType(getCurrency.toUpperCase()),
+          getType,
+          toAddress,
           pairFees: false,
         },
         () => {


### PR DESCRIPTION
## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/swaponline/MultiCurrencyWallet/blob/master/docs/CONTRIBUTING.md) guide
- [x] Good naming (as clear and simple as possible)
- [ ] Correct behavior if external API endpoints are down, return 404, 504 (or no answer), 401 errors (ddos simulation)
- [ ] I tested desktop/mobile resolution
- [ ] I tested light/dark theme
- [ ] I tested different languages
- [ ] I checked the functionality once again (**AFFECT MONEY**)
- [ ] I checked the work on the Testnet
- [ ] I checked the work on the Mainnet
- [ ] I checked the work in the plugin
- [x] I checked the **PR** once again

## Tests

Please start auto tests as follows:

- add a label <ins>swap test</ins> to start swap tests
- add a label <ins>withdraw test</ins> to start withdraw tests

You can skip these tests if you completely sure that your changes aren't related to this functional

### Original issue
<!-- Type number -->
- [x] #4657

### Video / screenshot proof
<!-- You can use Ctrl+V -->
