### PR TITLE
Create Order: fix display exchange rate

### DIFF
--- a/src/front/shared/components/modals/OfferModal/ConfirmOffer/ExchangeRate/ExchangeRate.tsx
+++ b/src/front/shared/components/modals/OfferModal/ConfirmOffer/ExchangeRate/ExchangeRate.tsx
@@ -7,7 +7,6 @@ import Row from '../Row/Row'
 import Value from '../Value/Value'
 import { FormattedMessage, injectIntl, defineMessages } from 'react-intl'
 import BigNumber from 'bignumber.js'
-import config from 'app-config'
 
 
 const title = defineMessages({
@@ -23,13 +22,13 @@ class ExchangeRate extends PureComponent<any, any> {
     const { sellCurrency, buyCurrency, exchangeRate, intl } = this.props
     return (
       <Row title={intl.formatMessage(title.ExchangeRate)}>
-        <Value value={1} currency={buyCurrency} />
+        <Value value={1} currency={sellCurrency} />
         {' '}
         <div styleName="equal">
           <FormattedMessage id="ExchangeRate14" defaultMessage="=" />
         </div>
         {' '}
-        <Value value={new BigNumber(exchangeRate).toString()} currency={sellCurrency} />
+        <Value value={new BigNumber(exchangeRate).toString()} currency={buyCurrency} />
       </Row>
     )
   }


### PR DESCRIPTION
## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/swaponline/MultiCurrencyWallet/blob/master/docs/CONTRIBUTING.md) guide
- [ ] Good naming (as clear and simple as possible)
- [ ] Correct behavior if external API endpoints are down, return 404, 504 (or no answer), 401 errors (ddos simulation)
- [ ] I tested desktop/mobile resolution
- [ ] I tested light/dark theme
- [ ] I tested different languages
- [ ] I checked the functionality once again (**AFFECT MONEY**)
- [ ] I checked the work on the Testnet
- [ ] I checked the work on the Mainnet
- [ ] I checked the work in the plugin
- [x] I checked the **PR** once again

## Tests

Please start auto tests as follows:

- add a label <ins>swap test</ins> to start swap tests
- add a label <ins>withdraw test</ins> to start withdraw tests

You can skip these tests if you completely sure that your changes aren't related to this functional

### Original issue
<!-- Type number -->

- [x] #4634

### Video / screenshot proof
<!-- You can use Ctrl+V -->

<img width="371" alt="Screen Shot 2021-07-22 at 16 52 30" src="https://user-images.githubusercontent.com/36531102/126628329-8afc9344-2623-4f1f-a001-55976de27189.png">