### PR TITLE
Add translations to multisig modal

### DIFF
--- a/src/front/shared/components/modals/BtcMultisignConfirmTx/BtcMultisignConfirmTx.tsx
+++ b/src/front/shared/components/modals/BtcMultisignConfirmTx/BtcMultisignConfirmTx.tsx
@@ -19,10 +19,6 @@ import Button from 'components/controls/Button/Button'
 import InlineLoader from 'components/loaders/InlineLoader/InlineLoader'
 import Tooltip from 'components/ui/Tooltip/Tooltip'
 import { FormattedMessage, injectIntl, defineMessages } from 'react-intl'
-import ReactTooltip from 'react-tooltip'
-import { isMobile } from 'react-device-detect'
-
-import links from 'helpers/links'
 
 import redirectTo from 'helpers/redirectTo'
 import lsDataCache from 'helpers/lsDataCache'
@@ -32,35 +28,35 @@ const langPrefix = `multiSignConfirmTxModal`
 const langLabels = defineMessages({
   title: {
     id: `${langPrefix}_Title`,
-    defaultMessage: `Подтверждение BTC Multisign транзакции`,
+    defaultMessage: `Confirmation of BTC Multisig transaction`,
   },
   noticeUp: {
     id: `${langPrefix}_UpNotice`,
-    defaultMessage: `Ознакомьтесь с транзакцией и подтвердите её. Если вы против списания, отмените тразакцию`,
+    defaultMessage: `Review the transaction and confirm it. If you are against the cancellation, reject the transaction`,
   },
   noticeFetching: {
     id: `${langPrefix}_NoticeFetching`,
-    defaultMessage: `Загрузка...`,
+    defaultMessage: `Loading...`,
   },
   confirmTx: {
     id: `${langPrefix}_ConfirmTx`,
-    defaultMessage: `Подтвердить`,
+    defaultMessage: `Confirm`,
   },
   dismatchTx: {
     id: `${langPrefix}_DismatchTx`,
-    defaultMessage: `Отклонить`,
+    defaultMessage: `Reject`,
   },
   youCantSignThis: {
     id: `${langPrefix}_YouCantSignThisTx`,
-    defaultMessage: `У вас нет прав для подписи этой транзакции (проверьте, что у вас создан мультисиг)`,
+    defaultMessage: `You do not have permission to sign this transaction (check that you have created a multisig)`,
   },
   goToWallet: {
     id: `${langPrefix}_GoToWalletPage`,
-    defaultMessage: `Открыть кошелек`,
+    defaultMessage: `Open wallet`,
   },
   buttonClose: {
     id: `${langPrefix}_ButtonClose`,
-    defaultMessage: `Закрыть`,
+    defaultMessage: `Close`,
   },
 })
 

--- a/src/front/shared/localisation/en.json
+++ b/src/front/shared/localisation/en.json
@@ -2811,35 +2811,35 @@
   },
   {
     "id": "multiSignConfirmTxModal_ConfirmTx",
-    "message": "Подтвердить",
+    "message": "Confirm",
     "files": [
       "src/front/shared/components/modals/BtcMultisignConfirmTx/BtcMultisignConfirmTx.tsx"
     ]
   },
   {
     "id": "multiSignConfirmTxModal_DismatchTx",
-    "message": "Отклонить",
+    "message": "Reject",
     "files": [
       "src/front/shared/components/modals/BtcMultisignConfirmTx/BtcMultisignConfirmTx.tsx"
     ]
   },
   {
     "id": "multiSignConfirmTxModal_NoticeFetching",
-    "message": "Загрузка...",
+    "message": "Loading...",
     "files": [
       "src/front/shared/components/modals/BtcMultisignConfirmTx/BtcMultisignConfirmTx.tsx"
     ]
   },
   {
     "id": "multiSignConfirmTxModal_Title",
-    "message": "Подтверждение BTC Multisign транзакции",
+    "message": "Confirmation of BTC Multisig transaction",
     "files": [
       "src/front/shared/components/modals/BtcMultisignConfirmTx/BtcMultisignConfirmTx.tsx"
     ]
   },
   {
     "id": "multiSignConfirmTxModal_UpNotice",
-    "message": "Ознакомьтесь с транзакцией и подтвердите её. Если вы против списания, отмените тразакцию",
+    "message": "Review the transaction and confirm it. If you are against the cancellation, reject the transaction",
     "files": [
       "src/front/shared/components/modals/BtcMultisignConfirmTx/BtcMultisignConfirmTx.tsx"
     ]

--- a/src/front/shared/localisation/nl.json
+++ b/src/front/shared/localisation/nl.json
@@ -2685,35 +2685,35 @@
   },
   {
     "id": "multiSignConfirmTxModal_ConfirmTx",
-    "message": "Подтвердить",
+    "message": "Bevestigen",
     "files": [
       "src/front/shared/components/modals/BtcMultisignConfirmTx/BtcMultisignConfirmTx.tsx"
     ]
   },
   {
     "id": "multiSignConfirmTxModal_DismatchTx",
-    "message": "Отклонить",
+    "message": "Afwijzen",
     "files": [
       "src/front/shared/components/modals/BtcMultisignConfirmTx/BtcMultisignConfirmTx.tsx"
     ]
   },
   {
     "id": "multiSignConfirmTxModal_NoticeFetching",
-    "message": "Загрузка...",
+    "message": "Bezig met laden...",
     "files": [
       "src/front/shared/components/modals/BtcMultisignConfirmTx/BtcMultisignConfirmTx.tsx"
     ]
   },
   {
     "id": "multiSignConfirmTxModal_Title",
-    "message": "Подтверждение BTC Multisign транзакции",
+    "message": "Bevestiging van BTC Multisig-transactie",
     "files": [
       "src/front/shared/components/modals/BtcMultisignConfirmTx/BtcMultisignConfirmTx.tsx"
     ]
   },
   {
     "id": "multiSignConfirmTxModal_UpNotice",
-    "message": "Ознакомьтесь с транзакцией и подтвердите её. Если вы против списания, отмените тразакцию",
+    "message": "Controleer de transactie en bevestig deze. Als u tegen de annulering bent, weiger dan de transactie",
     "files": [
       "src/front/shared/components/modals/BtcMultisignConfirmTx/BtcMultisignConfirmTx.tsx"
     ]
@@ -2983,14 +2983,14 @@
   },
   {
     "id": "multiSignConfirmTxModal_GoToWalletPage",
-    "message": "Open wallet",
+    "message": "Portemonnee openen",
     "files": [
       "src/front/shared/components/modals/BtcMultisignConfirmTx/BtcMultisignConfirmTx.tsx"
     ]
   },
   {
     "id": "multiSignConfirmTxModal_YouCantSignThisTx",
-    "message": "You do not have permission to sign this transaction (check that you have created a multisig)",
+    "message": "U heeft geen toestemming om deze transactie te ondertekenen (controleer of u een multisig heeft aangemaakt)",
     "files": [
       "src/front/shared/components/modals/BtcMultisignConfirmTx/BtcMultisignConfirmTx.tsx"
     ]
@@ -3569,7 +3569,7 @@
   },
   {
     "id": "multiSignConfirmTxModal_ButtonClose",
-    "message": "Close",
+    "message": "Dichtbij",
     "files": [
       "src/front/shared/components/modals/BtcMultisignConfirmTx/BtcMultisignConfirmTx.tsx"
     ]

--- a/src/front/shared/localisation/pl.json
+++ b/src/front/shared/localisation/pl.json
@@ -2696,35 +2696,35 @@
   },
   {
     "id": "multiSignConfirmTxModal_ConfirmTx",
-    "message": "Подтвердить",
+    "message": "Potwierdzać",
     "files": [
       "src/front/shared/components/modals/BtcMultisignConfirmTx/BtcMultisignConfirmTx.tsx"
     ]
   },
   {
     "id": "multiSignConfirmTxModal_DismatchTx",
-    "message": "Отклонить",
+    "message": "Odrzucić",
     "files": [
       "src/front/shared/components/modals/BtcMultisignConfirmTx/BtcMultisignConfirmTx.tsx"
     ]
   },
   {
     "id": "multiSignConfirmTxModal_NoticeFetching",
-    "message": "Загрузка...",
+    "message": "Ładowanie...",
     "files": [
       "src/front/shared/components/modals/BtcMultisignConfirmTx/BtcMultisignConfirmTx.tsx"
     ]
   },
   {
     "id": "multiSignConfirmTxModal_Title",
-    "message": "Подтверждение BTC Multisign транзакции",
+    "message": "Potwierdzenie transakcji BTC Multisig",
     "files": [
       "src/front/shared/components/modals/BtcMultisignConfirmTx/BtcMultisignConfirmTx.tsx"
     ]
   },
   {
     "id": "multiSignConfirmTxModal_UpNotice",
-    "message": "Ознакомьтесь с транзакцией и подтвердите её. Если вы против списания, отмените тразакцию",
+    "message": "Przejrzyj transakcję i potwierdź ją. Jeśli jesteś przeciwny anulowaniu, odrzuć transakcję",
     "files": [
       "src/front/shared/components/modals/BtcMultisignConfirmTx/BtcMultisignConfirmTx.tsx"
     ]
@@ -3001,7 +3001,7 @@
   },
   {
     "id": "multiSignConfirmTxModal_YouCantSignThisTx",
-    "message": "You do not have permission to sign this transaction (check that you have created a multisig)",
+    "message": "Nie masz uprawnień do podpisania tej transakcji (sprawdź, czy utworzyłeś multisig)",
     "files": [
       "src/front/shared/components/modals/BtcMultisignConfirmTx/BtcMultisignConfirmTx.tsx"
     ]
@@ -3580,7 +3580,7 @@
   },
   {
     "id": "multiSignConfirmTxModal_ButtonClose",
-    "message": "Close",
+    "message": "Blisko",
     "files": [
       "src/front/shared/components/modals/BtcMultisignConfirmTx/BtcMultisignConfirmTx.tsx"
     ]


### PR DESCRIPTION
## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/swaponline/MultiCurrencyWallet/blob/master/docs/CONTRIBUTING.md) guide
- [ ] Good naming (as clear and simple as possible)
- [ ] Correct behavior if external API endpoints are down, return 404, 504 (or no answer), 401 errors (ddos simulation)
- [ ] I tested desktop/mobile resolution
- [ ] I tested light/dark theme
- [x] I tested different languages
- [ ] I checked the functionality once again (**AFFECT MONEY**)
- [ ] I checked the work on the Testnet
- [ ] I checked the work on the Mainnet
- [ ] I checked the work in the plugin
- [x] I checked the **PR** once again

## Tests

Please start auto tests as follows:

- add a label <ins>swap test</ins> to start swap tests
- add a label <ins>withdraw test</ins> to start withdraw tests

You can skip these tests if you completely sure that your changes aren't related to this functional

### Original issue
<!-- Type number -->
#

### Video / screenshot proof
<!-- You can use Ctrl+V -->
