### PR TITLE
Hide widget tokens in wallet by default

### DIFF
--- a/src/front/shared/helpers/externalConfig.ts
+++ b/src/front/shared/helpers/externalConfig.ts
@@ -219,17 +219,18 @@ const externalConfig = () => {
   }
 
   if (config?.isWidget || config?.opts.ownTokens?.length) {
-    if (config?.opts.ownTokens?.length) {
-      config.opts.ownTokens.forEach((token) => {
-        config[token.standard][token.name.toLowerCase()] = token
+    // THIS IS CODE FOR SHOW ALL WIDGET TOKENS IN WALLET BY DEFAULT
+    // if (config?.opts.ownTokens?.length) {
+    //   config.opts.ownTokens.forEach((token) => {
+    //     config[token.standard][token.name.toLowerCase()] = token
 
-        const baseCurrency = TOKEN_STANDARDS[token.standard].currency.toUpperCase()
-        const tokenName = token.name.toUpperCase()
-        const tokenValue = `{${baseCurrency}}${tokenName}`
+    //     const baseCurrency = TOKEN_STANDARDS[token.standard].currency.toUpperCase()
+    //     const tokenName = token.name.toUpperCase()
+    //     const tokenValue = `{${baseCurrency}}${tokenName}`
 
-        reducers.core.markCoinAsVisible(tokenValue)
-      })
-    }
+    //     reducers.core.markCoinAsVisible(tokenValue)
+    //   })
+    // }
 
     // Clean not uninitialized single-token
     // ? we can't use here as whole string {#WIDGETTOKENCODE#} ?


### PR DESCRIPTION
## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/swaponline/MultiCurrencyWallet/blob/master/docs/CONTRIBUTING.md) guide
- [x] Good naming (as clear and simple as possible)
- [ ] Correct behavior if external API endpoints are down, return 404, 504 (or no answer), 401 errors (ddos simulation)
- [ ] I tested desktop/mobile resolution
- [ ] I tested light/dark theme
- [ ] I tested different languages
- [ ] I checked the functionality once again (**AFFECT MONEY**)
- [ ] I checked the work on the Testnet
- [ ] I checked the work on the Mainnet
- [ ] I checked the work in the plugin
- [x] I checked the **PR** once again

## Tests

Please start auto tests as follows:

- add a label <ins>swap test</ins> to start swap tests
- add a label <ins>withdraw test</ins> to start withdraw tests

You can skip these tests if you completely sure that your changes aren't related to this functional

### Original issue
<!-- Type number -->
#4713

### Video / screenshot proof
<!-- You can use Ctrl+V -->
