### PR TITLE
Remove wallet connect modal bg color

### DIFF
--- a/src/front/shared/components/modals/ConnectWalletModal/ConnectWalletModal.scss
+++ b/src/front/shared/components/modals/ConnectWalletModal/ConnectWalletModal.scss
@@ -30,7 +30,6 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background-color: rgba(0, 0, 0, .3);
   opacity: 1;
 
   &_dashboardView {

--- a/src/front/shared/components/modals/ConnectWalletModal/ConnectWalletModal.scss
+++ b/src/front/shared/components/modals/ConnectWalletModal/ConnectWalletModal.scss
@@ -30,6 +30,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  background-color: rgba(0, 0, 0, .3);
   opacity: 1;
 
   &_dashboardView {

--- a/src/front/shared/components/modals/ConnectWalletModal/ConnectWalletModal.tsx
+++ b/src/front/shared/components/modals/ConnectWalletModal/ConnectWalletModal.tsx
@@ -118,6 +118,7 @@ class ConnectWalletModal extends React.Component<any, null> {
       <div
         className={cx({
           [styles['modal-overlay']]: true,
+          [styles['modal-overlay_dashboardView']]: dashboardModalsAllowed,
         })}
       >
         <div


### PR DESCRIPTION
## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/swaponline/MultiCurrencyWallet/blob/master/docs/CONTRIBUTING.md) guide
- [x] Good naming (as clear and simple as possible)
- [ ] Correct behavior if external API endpoints are down, return 404, 504 (or no answer), 401 errors (ddos simulation)
- [ ] I tested desktop/mobile resolution
- [ ] I tested light/dark theme
- [ ] I tested different languages
- [ ] I checked the functionality once again (**AFFECT MONEY**)
- [ ] I checked the work on the Testnet
- [ ] I checked the work on the Mainnet
- [ ] I checked the work in the plugin
- [x] I checked the **PR** once again

## Tests

Please start auto tests as follows:

- add a label <ins>swap test</ins> to start swap tests
- add a label <ins>withdraw test</ins> to start withdraw tests

You can skip these tests if you completely sure that your changes aren't related to this functional

### Original issue
<!-- Type number -->
#4711

### Video / screenshot proof
<!-- You can use Ctrl+V -->
<img width="638" alt="Screen Shot 2021-09-02 at 12 39 15" src="https://user-images.githubusercontent.com/36531102/131794927-bf58bacb-3efb-48a7-afcb-f858a513168f.png">
