### PR TITLE
Don't redirect to 'Create Wallet' if `metamask` is connected

### DIFF
--- a/src/front/shared/components/Header/Header.tsx
+++ b/src/front/shared/components/Header/Header.tsx
@@ -8,7 +8,7 @@ import { connect } from 'redaction'
 
 import links from 'helpers/links'
 import actions from 'redux/actions'
-import { constants } from 'helpers'
+import { constants, metamask } from 'helpers'
 import config from 'helpers/externalConfig'
 import { injectIntl, FormattedMessage } from 'react-intl'
 
@@ -285,7 +285,7 @@ class Header extends Component<any, any> {
       case isWidgetBuild && !wasOnWidgetWalletLs:
         tourEvent = this.openWidgetWalletTour
         break
-      case !userCurrencies.length && isWalletPage && !config.opts.plugins.backupPlugin:
+      case !metamask.isConnected() && !userCurrencies.length && isWalletPage && !config.opts.plugins.backupPlugin:
         this.openCreateWallet({ onClose: tourEvent })
         break
       default:


### PR DESCRIPTION
## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/swaponline/MultiCurrencyWallet/blob/master/docs/CONTRIBUTING.md) guide
- [ ] Good naming (as clear and simple as possible)
- [ ] Correct behavior if external API endpoints are down, return 404, 504 (or no answer), 401 errors (ddos simulation)
- [ ] I tested desktop/mobile resolution
- [ ] I tested light/dark theme
- [ ] I tested different languages
- [ ] I checked the functionality once again (**AFFECT MONEY**)
- [ ] I checked the work on the Testnet
- [ ] I checked the work on the Mainnet
- [ ] I checked the work in the plugin
- [ ] I checked the **PR** once again

## Tests

Please start auto tests as follows:

- add a label <ins>swap test</ins> to start swap tests
- add a label <ins>withdraw test</ins> to start withdraw tests

You can skip these tests if you completely sure that your changes aren't related to this functional

### Original issue
<!-- Type number -->
#

### Video / screenshot proof
<!-- You can use Ctrl+V -->
