### PR TITLE
Plugin: disable stats by default

### DIFF
--- a/src/front/client/index.html
+++ b/src/front/client/index.html
@@ -657,7 +657,7 @@
 
           let url = 'https://noxon.wpmix.net/counter.php?msg=' + encodeURI(msg);
 
-          if (!window?.STATISTIC_DISABLED) {
+          if (!isWidgetBuild || window?.STATISTICS_ENABLED) {
             window.jQuery.ajax({
               type: 'POST',
               url: url,

--- a/src/front/client/index.tsx
+++ b/src/front/client/index.tsx
@@ -21,7 +21,7 @@ const __webpack_public_path__ = `${config.publicPath}images/` // It makes webpac
 const rootEl = document.getElementById('root')
 
 if (
-  !window?.STATISTIC_DISABLED &&
+  (!config.isWidget || window?.STATISTICS_ENABLED) &&
   process.env.NODE_ENV !== 'development'
 ) {
   Sentry.init({

--- a/src/front/shared/helpers/feedback.ts
+++ b/src/front/shared/helpers/feedback.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
-import { routing, links } from 'helpers'
+import { routing, links, externalConfig } from 'helpers'
 
-const isFeedbackEnabled = !window?.STATISTIC_DISABLED
+const isFeedbackEnabled = !externalConfig.isWidget || window?.STATISTICS_ENABLED
 const marks = {
   danger: '🔴',
   warning: '🔥',

--- a/src/front/shared/pages/Exchange/QuickSwap/index.tsx
+++ b/src/front/shared/pages/Exchange/QuickSwap/index.tsx
@@ -467,7 +467,7 @@ class QuickSwap extends PureComponent<IUniversalObj, ComponentState> {
       `sellAmount=${sellAmount}`,
     ]
 
-    if (!window?.STATISTIC_DISABLED) {
+    if (window?.STATISTICS_ENABLED) {
       request.push(`&affiliateAddress=${externalConfig.swapContract.affiliateAddress}`)
     }
 

--- a/src/front/shared/pages/Wallet/Wallet.tsx
+++ b/src/front/shared/pages/Wallet/Wallet.tsx
@@ -469,7 +469,7 @@ class Wallet extends PureComponent<any, any> {
       },
     } = this.props
 
-    if (window?.STATISTICS_ENABLED) {
+    if (!config.isWidget || window?.STATISTICS_ENABLED) {
       this.syncData()
     }
 

--- a/src/front/shared/pages/Wallet/Wallet.tsx
+++ b/src/front/shared/pages/Wallet/Wallet.tsx
@@ -469,7 +469,7 @@ class Wallet extends PureComponent<any, any> {
       },
     } = this.props
 
-    if (!window?.STATISTIC_DISABLED) {
+    if (window?.STATISTICS_ENABLED) {
       this.syncData()
     }
 


### PR DESCRIPTION
## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/swaponline/MultiCurrencyWallet/blob/master/docs/CONTRIBUTING.md) guide
- [ ] Good naming (as clear and simple as possible)
- [ ] Correct behavior if external API endpoints are down, return 404, 504 (or no answer), 401 errors (ddos simulation)
- [ ] I tested desktop/mobile resolution
- [ ] I tested light/dark theme
- [ ] I tested different languages
- [ ] I checked the functionality once again (**AFFECT MONEY**)
- [ ] I checked the work on the Testnet
- [x] I checked the work on the Mainnet
- [x] I checked the work in the plugin
- [x] I checked the **PR** once again

## Tests

Please start auto tests as follows:

- add a label <ins>swap test</ins> to start swap tests
- add a label <ins>withdraw test</ins> to start withdraw tests

You can skip these tests if you completely sure that your changes aren't related to this functional

### Original issue
#77

### Video / screenshot proof
<!-- You can use Ctrl+V -->
