### PR TITLE
Issue4900 - wp-admin: Add the ability to use only external wallets

### DIFF
--- a/src/front/client/index.html
+++ b/src/front/client/index.html
@@ -949,6 +949,7 @@
       window.darkLogoUrl = window.darkLogoUrl || '';
       window.loaderLogoUrl = window.loaderLogoUrl || '';
 
+      window.SO_disableInternalWallet = true
       if (window.localStorage.getItem('isDark')) {
         window.logoUrl = window.darkLogoUrl || window.logoUrl;
       }

--- a/src/front/client/index.html
+++ b/src/front/client/index.html
@@ -949,7 +949,6 @@
       window.darkLogoUrl = window.darkLogoUrl || '';
       window.loaderLogoUrl = window.loaderLogoUrl || '';
 
-      window.SO_disableInternalWallet = true
       if (window.localStorage.getItem('isDark')) {
         window.logoUrl = window.darkLogoUrl || window.logoUrl;
       }

--- a/src/front/shared/components/Header/config.tsx
+++ b/src/front/shared/components/Header/config.tsx
@@ -1,10 +1,12 @@
 import { defineMessages } from 'react-intl'
 import links from 'helpers/links'
 import externalConfig from 'helpers/externalConfig'
+import metamask from 'helpers/metamask'
 
 
 const isWidgetBuild = externalConfig && externalConfig.isWidget
 const isChromeExtension = externalConfig && externalConfig.dir === 'chrome-extension/application'
+const onlyEvmWallets = (externalConfig?.opts?.ui?.disableInternalWallet) ? true : false
 
 
 export const messages = defineMessages({
@@ -68,7 +70,7 @@ export const getMenuItems = (props) => {
   ]
 
   const itemsWithoutWallet = [
-    {
+    !onlyEvmWallets && {
       title: intl.formatMessage(createWallet),
       link: create,
       exact: true,
@@ -97,6 +99,8 @@ export const getMenuItems = (props) => {
     itemsWithWallet.push(marketmakerItem)
     itemsWithoutWallet.push(marketmakerItem)
   }
+
+  if (onlyEvmWallets && metamask.isConnected()) return itemsWithWallet
 
   return localStorage.getItem('isWalletCreate') === 'true'
     || externalConfig && externalConfig.isWidget

--- a/src/front/shared/components/modals/ConnectWalletModal/ConnectWalletModal.tsx
+++ b/src/front/shared/components/modals/ConnectWalletModal/ConnectWalletModal.tsx
@@ -128,7 +128,7 @@ class ConnectWalletModal extends React.Component<any, any> {
   }
 
   render() {
-    const { dashboardModalsAllowed } = this.props
+    const { dashboardModalsAllowed, noCloseButton } = this.props
     const { choseNetwork, currentBaseCurrency } = this.state
 
     return (
@@ -146,7 +146,9 @@ class ConnectWalletModal extends React.Component<any, any> {
         >
           <div styleName="header">
             <h3 styleName="title"><FormattedMessage id="Connect" defaultMessage="Connect" /></h3>
-            <CloseIcon onClick={this.handleClose} />
+            {!noCloseButton && (
+              <CloseIcon onClick={this.handleClose} />
+            )}
           </div>
 
           <div styleName="notification-overlay">

--- a/src/front/shared/helpers/externalConfig.ts
+++ b/src/front/shared/helpers/externalConfig.ts
@@ -94,7 +94,7 @@ const externalConfig = () => {
     && window.SO_disableInternalWallet
     && window.SO_disableInternalWallet
   ) {
-    config.opts.disableInternalWallet = window.SO_disableInternalWallet
+    config.opts.ui.disableInternalWallet = window.SO_disableInternalWallet
   }
   if (window
     && window.SO_fiatBuySupperted

--- a/src/front/shared/helpers/externalConfig.ts
+++ b/src/front/shared/helpers/externalConfig.ts
@@ -86,9 +86,16 @@ const externalConfig = () => {
       footerDisabled: false,
       farmLink: false, // use default link #/marketmaker
       bannersSource: 'https://noxon.wpmix.net/swapBanners/banners.php',
+      disableInternalWallet: false
     },
   }
 
+  if (window
+    && window.SO_disableInternalWallet
+    && window.SO_disableInternalWallet
+  ) {
+    config.opts.disableInternalWallet = window.SO_disableInternalWallet
+  }
   if (window
     && window.SO_fiatBuySupperted
     && window.SO_fiatBuySupperted.length

--- a/src/front/shared/pages/CreateWallet/CreateWallet.tsx
+++ b/src/front/shared/pages/CreateWallet/CreateWallet.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react'
-import config from 'app-config'
+import config from 'helpers/externalConfig'
 
 import CSSModules from 'react-css-modules'
 import styles from './CreateWallet.scss'
@@ -23,6 +23,7 @@ import CloseIcon from 'components/ui/CloseIcon/CloseIcon'
 import web3Icons from 'images'
 
 const isWidgetBuild = config && config.isWidget
+const noInternalWallet = (config?.opts?.ui?.disableInternalWallet) ? true : false
 
 const CreateWallet = (props) => {
   const {
@@ -255,30 +256,32 @@ const CreateWallet = (props) => {
           {forcedCurrency && forcedCurrency.toUpperCase()}
         </h2>
         <div styleName="buttonWrapper">
-          <div>
-            <button onClick={handleRestoreMnemonic}>
-              <FormattedMessage id="ImportKeys_RestoreMnemonic" defaultMessage="Restore from 12-word seed" />
-            </button>
-            &nbsp;
-            <Tooltip id="ImportKeys_RestoreMnemonic_tooltip">
-              <span>
-                <FormattedMessage
-                  id="ImportKeys_RestoreMnemonic_Tooltip"
-                  defaultMessage="12-word backup phrase"
-                />
-                <React.Fragment>
-                  <br />
-                  <br />
-                  <div styleName="alertTooltipWrapper">
-                    <FormattedMessage
-                      id="ImportKeys_RestoreMnemonic_Tooltip_withBalance"
-                      defaultMessage="Please, be causious!"
-                    />
-                  </div>
-                </React.Fragment>
-              </span>
-            </Tooltip>
-          </div>
+          {!noInternalWallet && (
+            <div>
+              <button onClick={handleRestoreMnemonic}>
+                <FormattedMessage id="ImportKeys_RestoreMnemonic" defaultMessage="Restore from 12-word seed" />
+              </button>
+              &nbsp;
+              <Tooltip id="ImportKeys_RestoreMnemonic_tooltip">
+                <span>
+                  <FormattedMessage
+                    id="ImportKeys_RestoreMnemonic_Tooltip"
+                    defaultMessage="12-word backup phrase"
+                  />
+                  <React.Fragment>
+                    <br />
+                    <br />
+                    <div styleName="alertTooltipWrapper">
+                      <FormattedMessage
+                        id="ImportKeys_RestoreMnemonic_Tooltip_withBalance"
+                        defaultMessage="Please, be causious!"
+                      />
+                    </div>
+                  </React.Fragment>
+                </span>
+              </Tooltip>
+            </div>
+          )}
           {!metamask.isConnected() && (
             <div>
               <button onClick={handleConnectWallet}>

--- a/src/front/shared/pages/CreateWallet/Steps/startPacks.ts
+++ b/src/front/shared/pages/CreateWallet/Steps/startPacks.ts
@@ -1,11 +1,12 @@
 import config from 'helpers/externalConfig'
 
 const curEnabled = config.opts.curEnabled
+const onlyEvmWallets = (config?.opts?.ui?.disableInternalWallet) ? true : false
 
 // TODO: Move it in a better place
 
 export const defaultPack = [
-  ...(!curEnabled || curEnabled.btc ? [{ name: 'BTC', capture: 'Bitcoin' }] : []),
+  ...(!(curEnabled || curEnabled.btc) && !onlyEvmWallets ? [{ name: 'BTC', capture: 'Bitcoin' }] : []),
 
   ...(!curEnabled || curEnabled.eth ? [{ name: 'ETH', capture: 'Ethereum' }] : []),
   ...(config.erc20 ? [{ name: 'ERC20', capture: 'Token', baseCurrency: 'ETH' }] : []),
@@ -18,8 +19,8 @@ export const defaultPack = [
 
   ...(!curEnabled || curEnabled.arbeth ? [{ name: 'ARBETH', capture: 'Arbitrum ETH' }] : []),
 
-  ...(!curEnabled || curEnabled.ghost ? [{ name: 'GHOST', capture: 'Ghost' }] : []),
-  ...(!curEnabled || curEnabled.next ? [{ name: 'NEXT', capture: 'NEXT.coin' }] : []),
+  ...(!(curEnabled || curEnabled.ghost) && !onlyEvmWallets ? [{ name: 'GHOST', capture: 'Ghost' }] : []),
+  ...(!(curEnabled || curEnabled.next) && !onlyEvmWallets ? [{ name: 'NEXT', capture: 'NEXT.coin' }] : []),
 
   ...(config.bep20 ? [{ name: 'BTCB', capture: 'BTCB Token', baseCurrency: 'BNB' }] : []),
   ...(config.erc20
@@ -36,7 +37,7 @@ export const defaultPack = [
 ]
 
 export const widgetPack = [
-  ...(!curEnabled || curEnabled.btc ? [{ name: 'BTC', capture: 'Bitcoin' }] : []),
+  ...(!(curEnabled || curEnabled.btc) && !onlyEvmWallets ? [{ name: 'BTC', capture: 'Bitcoin' }] : []),
   ...(!curEnabled || curEnabled.eth ? [{ name: 'ETH', capture: 'Ethereum' }] : []),
   ...(config.erc20 ? [{ name: 'ERC20', capture: 'Token', baseCurrency: 'ETH' }] : []),
   ...(!curEnabled || curEnabled.bnb ? [{ name: 'BNB', capture: 'Binance Coin' }] : []),
@@ -44,6 +45,6 @@ export const widgetPack = [
   ...(!curEnabled || curEnabled.matic ? [{ name: 'MATIC', capture: 'MATIC Token' }] : []),
   ...(config.erc20matic ? [{ name: 'ERC20MATIC', capture: 'Token', baseCurrency: 'MATIC' }] : []),
   ...(!curEnabled || curEnabled.arbeth ? [{ name: 'ARBETH', capture: 'Arbitrum ETH' }] : []),
-  ...(!curEnabled || curEnabled.ghost ? [{ name: 'GHOST', capture: 'Ghost' }] : []),
-  ...(!curEnabled || curEnabled.next ? [{ name: 'NEXT', capture: 'NEXT.coin' }] : []),
+  ...(!(curEnabled || curEnabled.ghost) && !onlyEvmWallets ? [{ name: 'GHOST', capture: 'Ghost' }] : []),
+  ...(!(curEnabled || curEnabled.next) && !onlyEvmWallets ? [{ name: 'NEXT', capture: 'NEXT.coin' }] : []),
 ]

--- a/src/front/shared/pages/CreateWallet/Steps/startPacks.ts
+++ b/src/front/shared/pages/CreateWallet/Steps/startPacks.ts
@@ -6,7 +6,7 @@ const onlyEvmWallets = (config?.opts?.ui?.disableInternalWallet) ? true : false
 // TODO: Move it in a better place
 
 export const defaultPack = [
-  ...(!(curEnabled || curEnabled.btc) && !onlyEvmWallets ? [{ name: 'BTC', capture: 'Bitcoin' }] : []),
+  ...((!curEnabled || curEnabled.btc) && !onlyEvmWallets ? [{ name: 'BTC', capture: 'Bitcoin' }] : []),
 
   ...(!curEnabled || curEnabled.eth ? [{ name: 'ETH', capture: 'Ethereum' }] : []),
   ...(config.erc20 ? [{ name: 'ERC20', capture: 'Token', baseCurrency: 'ETH' }] : []),
@@ -19,8 +19,8 @@ export const defaultPack = [
 
   ...(!curEnabled || curEnabled.arbeth ? [{ name: 'ARBETH', capture: 'Arbitrum ETH' }] : []),
 
-  ...(!(curEnabled || curEnabled.ghost) && !onlyEvmWallets ? [{ name: 'GHOST', capture: 'Ghost' }] : []),
-  ...(!(curEnabled || curEnabled.next) && !onlyEvmWallets ? [{ name: 'NEXT', capture: 'NEXT.coin' }] : []),
+  ...((!curEnabled || curEnabled.ghost) && !onlyEvmWallets ? [{ name: 'GHOST', capture: 'Ghost' }] : []),
+  ...((!curEnabled || curEnabled.next) && !onlyEvmWallets ? [{ name: 'NEXT', capture: 'NEXT.coin' }] : []),
 
   ...(config.bep20 ? [{ name: 'BTCB', capture: 'BTCB Token', baseCurrency: 'BNB' }] : []),
   ...(config.erc20
@@ -37,7 +37,7 @@ export const defaultPack = [
 ]
 
 export const widgetPack = [
-  ...(!(curEnabled || curEnabled.btc) && !onlyEvmWallets ? [{ name: 'BTC', capture: 'Bitcoin' }] : []),
+  ...((!curEnabled || curEnabled.btc) && !onlyEvmWallets ? [{ name: 'BTC', capture: 'Bitcoin' }] : []),
   ...(!curEnabled || curEnabled.eth ? [{ name: 'ETH', capture: 'Ethereum' }] : []),
   ...(config.erc20 ? [{ name: 'ERC20', capture: 'Token', baseCurrency: 'ETH' }] : []),
   ...(!curEnabled || curEnabled.bnb ? [{ name: 'BNB', capture: 'Binance Coin' }] : []),
@@ -45,6 +45,6 @@ export const widgetPack = [
   ...(!curEnabled || curEnabled.matic ? [{ name: 'MATIC', capture: 'MATIC Token' }] : []),
   ...(config.erc20matic ? [{ name: 'ERC20MATIC', capture: 'Token', baseCurrency: 'MATIC' }] : []),
   ...(!curEnabled || curEnabled.arbeth ? [{ name: 'ARBETH', capture: 'Arbitrum ETH' }] : []),
-  ...(!(curEnabled || curEnabled.ghost) && !onlyEvmWallets ? [{ name: 'GHOST', capture: 'Ghost' }] : []),
-  ...(!(curEnabled || curEnabled.next) && !onlyEvmWallets ? [{ name: 'NEXT', capture: 'NEXT.coin' }] : []),
+  ...((!curEnabled || curEnabled.ghost) && !onlyEvmWallets ? [{ name: 'GHOST', capture: 'Ghost' }] : []),
+  ...((!curEnabled || curEnabled.next) && !onlyEvmWallets ? [{ name: 'NEXT', capture: 'NEXT.coin' }] : []),
 ]

--- a/src/front/shared/pages/Exchange/AddressSelect/AddressSelect.tsx
+++ b/src/front/shared/pages/Exchange/AddressSelect/AddressSelect.tsx
@@ -24,10 +24,13 @@ import iconInternal from 'images/logo/logo-black.svg'
 import iconCustom from 'images/custom.svg'
 
 import getCoinInfo from 'common/coins/getCoinInfo'
+import config from 'helpers/externalConfig'
+
 
 import { AddressType, AddressRole } from 'domain/address'
 import { COIN_DATA, COIN_MODEL } from 'swap.app/constants/COINS'
 
+const disableInternalWallet = (config?.opts?.ui?.disableInternalWallet) ? true : false
 const langLabels = defineMessages({
   labelSpecifyAddress: {
     id: 'Exchange_SpecifyAddress',
@@ -369,34 +372,36 @@ class AddressSelect extends Component<AddressSelectProps, AddressSelectState> {
 
     const isCurrencyInInternalWallet = this.isCurrencyInInternalWallet()
 
-    if (isCurrencyInInternalWallet) {
-      dropDownOptions.push(
-        {
-          value: AddressType.Internal,
-          icon: iconInternal,
-          title: !isInternalOptionDisabled ? (
-            <Fragment>
-              <FormattedMessage {...langLabels.optionInternal} />
-              <Address
-                address={this.getInternalAddress()}
-                format={AddressFormat.Short}
-                type={AddressType.Internal}
-              />
-            </Fragment>
-          ) : (
-            <FormattedMessage {...langLabels.optionInternalDisabled} />
-          ),
-          disabled: isInternalOptionDisabled,
-        },
-      )
-    } else if (isUTXOModel || !isMetamaskConnected) {
-      dropDownOptions.push(
-        {
-          value: 'InternalAddressCreate',
-          icon: iconInternal,
-          title: <FormattedMessage {...langLabels.optionInternalCreate} />,
-        },
-      )
+    if (!disableInternalWallet) {
+      if (isCurrencyInInternalWallet) {
+        dropDownOptions.push(
+          {
+            value: AddressType.Internal,
+            icon: iconInternal,
+            title: !isInternalOptionDisabled ? (
+              <Fragment>
+                <FormattedMessage {...langLabels.optionInternal} />
+                <Address
+                  address={this.getInternalAddress()}
+                  format={AddressFormat.Short}
+                  type={AddressType.Internal}
+                />
+              </Fragment>
+            ) : (
+              <FormattedMessage {...langLabels.optionInternalDisabled} />
+            ),
+            disabled: isInternalOptionDisabled,
+          },
+        )
+      } else if (isUTXOModel || !isMetamaskConnected) {
+        dropDownOptions.push(
+          {
+            value: 'InternalAddressCreate',
+            icon: iconInternal,
+            title: <FormattedMessage {...langLabels.optionInternalCreate} />,
+          },
+        )
+      }
     }
 
     if (isMetamaskOption) {

--- a/src/front/shared/pages/Exchange/QuickSwap/UserInfo.tsx
+++ b/src/front/shared/pages/Exchange/QuickSwap/UserInfo.tsx
@@ -16,6 +16,10 @@ import Button from 'components/controls/Button/Button'
 import Tooltip from 'components/ui/Tooltip/Tooltip'
 import { COIN_DECIMALS, MAX_PERCENT } from './constants'
 import { ServiceFee } from './types'
+import config from 'helpers/externalConfig'
+
+
+const onlyEvmWallets = (config?.opts?.ui?.disableInternalWallet) ? true : false
 
 type ComponentProps = {
   history: any
@@ -121,47 +125,66 @@ function UserInfo(props: ComponentProps) {
     }
   }
 
+  const connectWalletButton = (
+    <Button
+      id="connectWalletBtn"
+      brand
+      fullWidth
+      styleName="walletButton"
+      onClick={connectWallet}
+    >
+      <FormattedMessage id="Exchange_ConnectAddressOption" defaultMessage="Connect Wallet" />
+    </Button>
+  )
+  const walletAddressBlock = (
+    <span styleName="indicator">
+      <FormattedMessage id="addressOfYourWallet" defaultMessage="Address of your wallet:" />
+
+      <Copy text={fromWallet.address}>
+        <span styleName="value address">
+          <Address
+            address={fromWallet.address}
+            format={isMobile ? AddressFormat.Short : AddressFormat.Full}
+            type={metamask.isConnected() ? AddressType.Metamask : AddressType.Internal}
+          />
+        </span>
+      </Copy>
+    </span>
+  )
+
   return (
     <section styleName="userInfo">
-      {!metamask.isConnected() && (!isWalletCreated || !mnemonicSaved) && (
-        <Button
-          id="connectWalletBtn"
-          brand
-          fullWidth
-          styleName="walletButton"
-          onClick={connectWallet}
-        >
-          <FormattedMessage id="Exchange_ConnectAddressOption" defaultMessage="Connect Wallet" />
-        </Button>
-      )}
-      {!isWalletCreated ? (
-        <Button id="createWalletBtn" styleName="walletButton" gray fullWidth onClick={createWallet}>
-          <FormattedMessage id="menu.CreateWallet" defaultMessage="Create wallet" />
-        </Button>
-      ) : saveSecretPhrase ? (
-        <Button
-          id="saveSecretPhraseBtn"
-          styleName="walletButton"
-          gray
-          fullWidth
-          onClick={saveMnemonic}
-        >
-          <FormattedMessage id="BTCMS_SaveMnemonicButton" defaultMessage="Save secret phrase" />
-        </Button>
+      {onlyEvmWallets ? (
+        <>
+          {!metamask.isConnected() ? (
+            <>{connectWalletButton}</>
+          ) : (
+            <>{walletAddressBlock}</>
+          )}
+        </>
       ) : (
-        <span styleName="indicator">
-          <FormattedMessage id="addressOfYourWallet" defaultMessage="Address of your wallet:" />
-
-          <Copy text={fromWallet.address}>
-            <span styleName="value address">
-              <Address
-                address={fromWallet.address}
-                format={isMobile ? AddressFormat.Short : AddressFormat.Full}
-                type={metamask.isConnected() ? AddressType.Metamask : AddressType.Internal}
-              />
-            </span>
-          </Copy>
-        </span>
+        <>
+          {!metamask.isConnected() && (!isWalletCreated || !mnemonicSaved) && (
+            <>{connectWalletButton}</>
+          )}
+          {!isWalletCreated ? (
+            <Button id="createWalletBtn" styleName="walletButton" gray fullWidth onClick={createWallet}>
+              <FormattedMessage id="menu.CreateWallet" defaultMessage="Create wallet" />
+            </Button>
+          ) : saveSecretPhrase ? (
+            <Button
+              id="saveSecretPhraseBtn"
+              styleName="walletButton"
+              gray
+              fullWidth
+              onClick={saveMnemonic}
+            >
+              <FormattedMessage id="BTCMS_SaveMnemonicButton" defaultMessage="Save secret phrase" />
+            </Button>
+          ) : (
+            <>{walletAddressBlock}</>
+          )}
+        </>
       )}
 
       <span styleName="indicator">

--- a/src/front/shared/pages/Exchange/index.tsx
+++ b/src/front/shared/pages/Exchange/index.tsx
@@ -6,6 +6,7 @@ import { localStorage, constants, links } from 'helpers'
 import QuickSwap from './QuickSwap'
 import AtomicSwap from './AtomicSwap'
 
+
 // option from the WP panel
 const globalMode = window.exchangeMode
 

--- a/src/front/shared/pages/Wallet/CurrenciesList.tsx
+++ b/src/front/shared/pages/Wallet/CurrenciesList.tsx
@@ -1,6 +1,7 @@
 import React, { Fragment } from 'react'
 import CSSModules from 'react-css-modules'
 import config from 'app-config'
+import metamask from 'helpers/metamask'
 import styles from './Wallet.scss'
 import Button from 'components/controls/Button/Button'
 import Row from './Row/Row'
@@ -9,6 +10,8 @@ import Table from 'components/tables/Table/Table'
 
 import { FormattedMessage } from 'react-intl'
 import exConfig from 'helpers/externalConfig'
+import ConnectWalletModal from 'components/modals/ConnectWalletModal/ConnectWalletModal'
+
 
 const isWidgetBuild = config && config.isWidget
 
@@ -26,40 +29,52 @@ const CurrenciesList = (props: CurrenciesListProps) => {
     multisigPendingCount,
   } = props
 
+  const showAssets = !(config?.opts?.ui?.disableInternalWallet)
+    ? true
+    : (metamask.isConnected()) ? true : false
   return (
     <div styleName="yourAssets">
-      {(exConfig && exConfig.opts && exConfig.opts.showWalletBanners) || isWidgetBuild ? (
-        <Fragment>
-          <Slider multisigPendingCount={multisigPendingCount} />
-        </Fragment>
-      ) : (
-        ''
-      )}
-      <h3 styleName="yourAssetsHeading">
-        <FormattedMessage id="YourAssets" defaultMessage="Your assets" />
-      </h3>
-      <div styleName="yourAssetsDescr">
-        <FormattedMessage
-          id="YourAssetsDescription"
-          defaultMessage="Here you can safely store, send and receive assets"
-        />
-      </div>
-      <Table
-        className={`${styles.walletTable} data-tut-address`}
-        rows={tableRows}
-        rowRender={(row, index) => (
-          <Row
-            key={index}
-            currency={row}
-            itemData={row}
+      {showAssets && (
+        <>
+          {(exConfig && exConfig.opts && exConfig.opts.showWalletBanners) || isWidgetBuild ? (
+            <Fragment>
+              <Slider multisigPendingCount={multisigPendingCount} />
+            </Fragment>
+          ) : (
+            ''
+          )}
+          <h3 styleName="yourAssetsHeading">
+            <FormattedMessage id="YourAssets" defaultMessage="Your assets" />
+          </h3>
+          <div styleName="yourAssetsDescr">
+            <FormattedMessage
+              id="YourAssetsDescription"
+              defaultMessage="Here you can safely store, send and receive assets"
+            />
+          </div>
+          <Table
+            className={`${styles.walletTable} data-tut-address`}
+            rows={tableRows}
+            rowRender={(row, index) => (
+              <Row
+                key={index}
+                currency={row}
+                itemData={row}
+              />
+            )}
           />
-        )}
-      />
-      <div styleName='addCurrencyBtnWrapper'>
-        <Button id="addAssetBtn" onClick={goToСreateWallet} transparent fullWidth>
-          <FormattedMessage id="addAsset" defaultMessage="Add currency" />
-        </Button>
-      </div>
+          <div styleName='addCurrencyBtnWrapper'>
+            <Button id="addAssetBtn" onClick={goToСreateWallet} transparent fullWidth>
+              <FormattedMessage id="addAsset" defaultMessage="Add currency" />
+            </Button>
+          </div>
+        </>
+      )}
+      {!showAssets && !metamask.isConnected() && (
+        <>
+          <ConnectWalletModal noCloseButton={true}></ConnectWalletModal>
+        </>
+      )}
     </div>
   )
 }

--- a/src/front/shared/pages/Wallet/WallerSlider/index.tsx
+++ b/src/front/shared/pages/Wallet/WallerSlider/index.tsx
@@ -17,6 +17,8 @@ import { FormattedMessage, injectIntl } from 'react-intl'
 import linksManager from 'helpers/links'
 
 
+const disableInternalWallet = (config?.opts?.ui?.disableInternalWallet) ? true : false
+
 type WallerSliderProps = {
   intl?: { [key: string]: any }
   user?: { [key: string]: any }
@@ -217,7 +219,7 @@ class WallerSlider extends React.Component<WallerSliderProps, WallerSliderState>
                   />
                 </div>
               )}
-              {!isPrivateKeysSaved && !mnemonicDeleted && (
+              {!isPrivateKeysSaved && !mnemonicDeleted && !disableInternalWallet && (
                 <div className="swiper-slide">
                   <NotifyBlock
                     className="notifyBlockSaveKeys"

--- a/src/front/shared/redux/actions/core.ts
+++ b/src/front/shared/redux/actions/core.ts
@@ -459,6 +459,8 @@ const getWallet = (params: GetWalletParams) => {
 const getWallets = (options: IUniversalObj = {}) => {
   const { withInternal } = options
 
+  const onlyEvmWallets = (config?.opts?.ui?.disableInternalWallet) ? true : false
+
   const {
     user: {
       btcData,
@@ -505,17 +507,17 @@ const getWallets = (options: IUniversalObj = {}) => {
           : []
         : []
     ),
-    ...(!enabledCurrencies || enabledCurrencies.btc
+    ...((!enabledCurrencies || enabledCurrencies.btc) && !onlyEvmWallets
       ? [btcData, btcMultisigSMSData, btcMultisigUserData]
       : []
     ),
-    ...(!enabledCurrencies || enabledCurrencies.btc
+    ...((!enabledCurrencies || enabledCurrencies.btc) && !onlyEvmWallets
       ? btcMultisigPinData && btcMultisigPinData.isRegistered
         ? [btcMultisigPinData]
         : []
       : []),
     // =====================================
-    ...(!enabledCurrencies || enabledCurrencies.btc
+    ...((!enabledCurrencies || enabledCurrencies.btc) && !onlyEvmWallets
       ? btcMultisigUserData && btcMultisigUserData.wallets
         ? btcMultisigUserData.wallets
         : []
@@ -553,8 +555,8 @@ const getWallets = (options: IUniversalObj = {}) => {
         : [arbethData]
       : []),
     // =====================================
-    ...(!enabledCurrencies || enabledCurrencies.ghost ? [ghostData] : []),
-    ...(!enabledCurrencies || enabledCurrencies.next ? [nextData] : []),
+    ...((!enabledCurrencies || enabledCurrencies.ghost) && !onlyEvmWallets ? [ghostData] : []),
+    ...((!enabledCurrencies || enabledCurrencies.next) && !onlyEvmWallets ? [nextData] : []),
     ...tokenWallets,
   ].map(({ account, keyPair, ...data }) => ({
     ...data,


### PR DESCRIPTION
## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/swaponline/MultiCurrencyWallet/blob/master/docs/CONTRIBUTING.md) guide
- [ ] Good naming (as clear and simple as possible)
- [ ] Correct behavior if external API endpoints are down, return 404, 504 (or no answer), 401 errors (ddos simulation)
- [ ] I tested desktop/mobile resolution
- [ ] I tested light/dark theme
- [ ] I tested different languages
- [ ] I checked the functionality once again (**AFFECT MONEY**)
- [ ] I checked the work on the Testnet
- [ ] I checked the work on the Mainnet
- [ ] I checked the work in the plugin
- [ ] I checked the **PR** once again

## Tests

Please start auto tests as follows:

- add a label <ins>swap test</ins> to start swap tests
- add a label <ins>withdraw test</ins> to start withdraw tests

You can skip these tests if you completely sure that your changes aren't related to this functional

### Original issue
https://github.com/swaponline/MultiCurrencyWallet/issues/4900
#

Добавил опцию 
`window.SO_disableInternalWallet`
Дублируется через
`window.buildOptions.ui.disableInternalWallet`
### Video / screenshot proof
<!-- You can use Ctrl+V -->
