### PR TITLE
quick swap - show Exchange if only source enabled

### DIFF
--- a/src/front/shared/pages/Exchange/QuickSwap/Header.tsx
+++ b/src/front/shared/pages/Exchange/QuickSwap/Header.tsx
@@ -20,6 +20,10 @@ function Header(props) {
     openSettingsSection,
   } = props
 
+  let sourceTitle = LIQUIDITY_SOURCE_DATA[network.networkVersion]?.name || (
+    <FormattedMessage id="source" defaultMessage="Source" />
+  )
+  if (onlySource) sourceTitle = <FormattedMessage id="sourceExchange" defaultMessage="Exchange" />
   return (
     <div styleName="header">
       {!onlySource && (
@@ -39,9 +43,7 @@ function Header(props) {
           styleName={`tab ${activeSection === Sections.Source ? 'active' : ''}`}
           onClick={openSourceSection}
         >
-          {LIQUIDITY_SOURCE_DATA[network.networkVersion]?.name || (
-            <FormattedMessage id="source" defaultMessage="Source" />
-          )}
+          {sourceTitle}
         </button>
       )}
 


### PR DESCRIPTION
## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/swaponline/MultiCurrencyWallet/blob/master/docs/CONTRIBUTING.md) guide
- [ ] Good naming (as clear and simple as possible)
- [ ] Correct behavior if external API endpoints are down, return 404, 504 (or no answer), 401 errors (ddos simulation)
- [ ] I tested desktop/mobile resolution
- [ ] I tested light/dark theme
- [ ] I tested different languages
- [ ] I checked the functionality once again (**AFFECT MONEY**)
- [ ] I checked the work on the Testnet
- [ ] I checked the work on the Mainnet
- [ ] I checked the work in the plugin
- [ ] I checked the **PR** once again

## Tests

Please start auto tests as follows:

- add a label <ins>swap test</ins> to start swap tests
- add a label <ins>withdraw test</ins> to start withdraw tests

You can skip these tests if you completely sure that your changes aren't related to this functional

### Original issue
https://github.com/swaponline/MultiCurrencyWallet/issues/4943
#

### Video / screenshot proof
<!-- You can use Ctrl+V -->
