### PR TITLE
Wallet connect - dont show disabled networks

### DIFF
--- a/src/front/shared/components/modals/ConnectWalletModal/ConnectWalletModal.tsx
+++ b/src/front/shared/components/modals/ConnectWalletModal/ConnectWalletModal.tsx
@@ -162,7 +162,11 @@ class ConnectWalletModal extends React.Component<any, any> {
                 <FormattedMessage id="chooseNetwork" defaultMessage="Choose network" />
               </h3>
               <div styleName="options">
-                {Object.values(externalConfig.evmNetworks).map(
+                {Object.values(externalConfig.evmNetworks)
+                  .filter( (network: any) => {
+                    return externalConfig.opts.curEnabled[network.currency.toLowerCase()]
+                  })
+                  .map(
                   (
                     item: {
                       currency: string


### PR DESCRIPTION
## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/swaponline/MultiCurrencyWallet/blob/master/docs/CONTRIBUTING.md) guide
- [ ] Good naming (as clear and simple as possible)
- [ ] Correct behavior if external API endpoints are down, return 404, 504 (or no answer), 401 errors (ddos simulation)
- [ ] I tested desktop/mobile resolution
- [ ] I tested light/dark theme
- [ ] I tested different languages
- [ ] I checked the functionality once again (**AFFECT MONEY**)
- [ ] I checked the work on the Testnet
- [ ] I checked the work on the Mainnet
- [ ] I checked the work in the plugin
- [ ] I checked the **PR** once again

## Tests

Please start auto tests as follows:

- add a label <ins>swap test</ins> to start swap tests
- add a label <ins>withdraw test</ins> to start withdraw tests

You can skip these tests if you completely sure that your changes aren't related to this functional

### Original issue
<!-- Type number -->
#

### Video / screenshot proof
![image](https://user-images.githubusercontent.com/1880211/144425122-fb9ff8d7-272f-4391-98e6-6531c2da628a.png)

![image](https://user-images.githubusercontent.com/1880211/144424589-bccbc86b-a133-4f85-80cd-80d56e7c2c4e.png)

