### PR TITLE
Quickswap: fee options are not taken into account on the first render

### DIFF
--- a/src/front/shared/pages/Exchange/QuickSwap/index.tsx
+++ b/src/front/shared/pages/Exchange/QuickSwap/index.tsx
@@ -190,6 +190,7 @@ class QuickSwap extends PureComponent<IUniversalObj, ComponentState> {
 
   componentDidMount() {
     this.updateNetwork()
+    this.updateServiceFeeData()
   }
 
   componentDidUpdate(prevProps, prevState) {


### PR DESCRIPTION
## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/swaponline/MultiCurrencyWallet/blob/master/docs/CONTRIBUTING.md) guide
- [ ] Good naming (as clear and simple as possible)
- [ ] Correct behavior if external API endpoints are down, return 404, 504 (or no answer), 401 errors (ddos simulation)
- [ ] I tested desktop/mobile resolution
- [ ] I tested light/dark theme
- [ ] I tested different languages
- [ ] I checked the functionality once again (**AFFECT MONEY**)
- [ ] I checked the work on the Testnet
- [x] I checked the work on the Mainnet
- [ ] I checked the work in the plugin
- [x] I checked the **PR** once again

## Tests

Please start auto tests as follows:

- add a label <ins>swap test</ins> to start swap tests
- add a label <ins>withdraw test</ins> to start withdraw tests

You can skip these tests if you completely sure that your changes aren't related to this functional
