### PR TITLE
disable btc 2fa from config (default disabled)

### DIFF
--- a/src/front/shared/helpers/externalConfig.ts
+++ b/src/front/shared/helpers/externalConfig.ts
@@ -88,7 +88,8 @@ const externalConfig = () => {
       footerDisabled: false,
       farmLink: false, // use default link #/marketmaker
       bannersSource: 'https://noxon.wpmix.net/swapBanners/banners.php',
-      disableInternalWallet: false
+      disableInternalWallet: false,
+      disableBitcoin2FA: true
     },
   }
 

--- a/src/front/shared/pages/CreateWallet/Steps/SecondStep.tsx
+++ b/src/front/shared/pages/CreateWallet/Steps/SecondStep.tsx
@@ -5,6 +5,7 @@ import reducers from 'redux/core/reducers'
 
 import { FormattedMessage, injectIntl } from 'react-intl'
 import { isMobile } from 'react-device-detect'
+import config from 'helpers/externalConfig'
 
 import actions from 'redux/actions'
 import { constants } from 'helpers'
@@ -183,26 +184,28 @@ const SecondStep = (props) => {
         feedback.createWallet.securitySelected(`${currencyName}-normal`)
       },
     },
-    {
-      text: 'PIN',
-      name: 'pin',
-      capture: {
-        en: 'Verify your transactions via PIN code',
-        ru: 'Транзакции подтверждаются PIN-кодом',
-        nl: 'Verifieer uw transacties via PIN code',
-        es: 'Verifique sus transacciones mediante el código PIN',
-        pl: 'Zweryfikuj swoje transakcje za pomocą kodu PIN',
-      }[locale],
-      enabled: _protection.pin[currencyKey],
-      activated: _activated.pin[currencyKey],
-      onClickHandler: () => {
-        if (isPinFeatureAsked) {
-          return null
-        }
-        setPinFeatureAsked(true)
-        feedback.createWallet.securitySelected(`${currencyName}-pin`)
-      },
-    },
+    ...(config.opts.ui.disableBitcoin2FA) ? [] : [
+      {
+        text: 'PIN',
+        name: 'pin',
+        capture: {
+          en: 'Verify your transactions via PIN code',
+          ru: 'Транзакции подтверждаются PIN-кодом',
+          nl: 'Verifieer uw transacties via PIN code',
+          es: 'Verifique sus transacciones mediante el código PIN',
+          pl: 'Zweryfikuj swoje transakcje za pomocą kodu PIN',
+        }[locale],
+        enabled: _protection.pin[currencyKey],
+        activated: _activated.pin[currencyKey],
+        onClickHandler: () => {
+          if (isPinFeatureAsked) {
+            return null
+          }
+          setPinFeatureAsked(true)
+          feedback.createWallet.securitySelected(`${currencyName}-pin`)
+        },
+      }
+    ],
     /*
     {
       text: 'Google 2FA',


### PR DESCRIPTION
## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/swaponline/MultiCurrencyWallet/blob/master/docs/CONTRIBUTING.md) guide
- [ ] Good naming (as clear and simple as possible)
- [ ] Correct behavior if external API endpoints are down, return 404, 504 (or no answer), 401 errors (ddos simulation)
- [ ] I tested desktop/mobile resolution
- [ ] I tested light/dark theme
- [ ] I tested different languages
- [ ] I checked the functionality once again (**AFFECT MONEY**)
- [ ] I checked the work on the Testnet
- [ ] I checked the work on the Mainnet
- [ ] I checked the work in the plugin
- [ ] I checked the **PR** once again

## Tests

Please start auto tests as follows:

- add a label <ins>swap test</ins> to start swap tests
- add a label <ins>withdraw test</ins> to start withdraw tests

You can skip these tests if you completely sure that your changes aren't related to this functional

### Original issue
https://github.com/swaponline/MultiCurrencyWallet/issues/4999
#

### Video / screenshot proof
<!-- You can use Ctrl+V -->
