### PR TITLE
Quickswap: error with undefined wallet. Quickswap and connection are available with disabled EVMs

### DIFF
--- a/src/front/shared/components/Header/Header.tsx
+++ b/src/front/shared/components/Header/Header.tsx
@@ -447,7 +447,9 @@ class Header extends Component<any, any> {
           {!isMobile && <Nav menu={menuItems} />}
         </div>
         <div styleName="rightArea">
-          {!config.isExtension && <WalletConnect />}
+          {!config.isExtension && Object.values(config.enabledEvmNetworks).length ? (
+            <WalletConnect />
+          ) : null}
 
           {window.WPSO_selected_theme !== 'only_light' && window.WPSO_selected_theme !== 'only_dark' && (
             <ThemeSwitcher onClick={this.handleToggleTheme} />

--- a/src/front/shared/helpers/externalConfig.ts
+++ b/src/front/shared/helpers/externalConfig.ts
@@ -241,6 +241,17 @@ const externalConfig = () => {
     config.opts.blockchainSwapEnabled.xdai = false
   }
 
+  config.enabledEvmNetworks = Object.keys(config.evmNetworks)
+    .filter((key) => config.opts.curEnabled[key.toLowerCase()])
+    .reduce((acc, key) => {
+      acc[key] = config.evmNetworks[key]
+
+      return acc
+    }, {})
+
+  config.enabledEvmNetworkVersions = Object.values(config.enabledEvmNetworks).map(
+    (info: { networkVersion: number }) => info.networkVersion
+  )
 
   // Plugins
   if (window

--- a/src/front/shared/pages/Exchange/QuickSwap/index.tsx
+++ b/src/front/shared/pages/Exchange/QuickSwap/index.tsx
@@ -337,7 +337,7 @@ class QuickSwap extends PureComponent<IUniversalObj, ComponentState> {
     const { fromWallet } = this.state
 
     const feeOptsKey = fromWallet?.standard || fromWallet?.currency
-    const currentFeeOpts = externalConfig.opts.fee[feeOptsKey.toLowerCase()]
+    const currentFeeOpts = externalConfig.opts.fee[feeOptsKey?.toLowerCase()]
     const correctFeeRepresentation =
       !Number.isNaN(window?.zeroxFeePercent) &&
       window.zeroxFeePercent >= 0 &&

--- a/src/front/shared/pages/Exchange/index.tsx
+++ b/src/front/shared/pages/Exchange/index.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { FormattedMessage } from 'react-intl'
 import CSSModules from 'react-css-modules'
-import { localStorage, constants, links } from 'helpers'
+import { localStorage, constants, links, externalConfig } from 'helpers'
 import styles from './index.scss'
 import QuickSwap from './QuickSwap'
 import AtomicSwap from './AtomicSwap'
@@ -19,13 +19,20 @@ const GlobalModes = {
 const Exchange = function (props) {
   const { location, history } = props
 
+  const noNetworks = !Object.values(externalConfig.enabledEvmNetworks).length
+
   const validMode = globalMode && GlobalModes[globalMode]
-  const showOnlyOneType = validMode === GlobalModes.only_atomic || validMode === GlobalModes.only_quick
+  let showOnlyOneType = validMode === GlobalModes.only_atomic || validMode === GlobalModes.only_quick
 
   const exchangeSettings = localStorage.getItem(constants.localStorage.exchangeSettings) || {}
   let initialState = location.pathname.match(/\/exchange\/quick/) ? 'quick' : 'atomic'
 
-  if (showOnlyOneType) {
+  if (noNetworks) {
+    showOnlyOneType = true
+    initialState = GlobalModes.atomic
+    exchangeSettings.swapMode = initialState
+    localStorage.setItem(constants.localStorage.exchangeSettings, exchangeSettings)
+  } else if (showOnlyOneType) {
     // and hide tabs next
     initialState = globalMode.replace(/only_/, '')
   } else if (validMode && location.pathname === '/exchange') {
@@ -92,7 +99,7 @@ const Exchange = function (props) {
         </div>
       )}
 
-      {swapMode === 'quick' && (
+      {swapMode === 'quick' && !noNetworks && (
         <div styleName="container">
           {/* pass props from this component into the components
         because there has to be "url" props like match, location, etc.


### PR DESCRIPTION
## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/swaponline/MultiCurrencyWallet/blob/master/docs/CONTRIBUTING.md) guide
- [ ] Good naming (as clear and simple as possible)
- [ ] Correct behavior if external API endpoints are down, return 404, 504 (or no answer), 401 errors (ddos simulation)
- [ ] I tested desktop/mobile resolution
- [x] I tested light/dark theme
- [ ] I tested different languages
- [ ] I checked the functionality once again (**AFFECT MONEY**)
- [ ] I checked the work on the Testnet
- [x] I checked the work on the Mainnet
- [x] I checked the work in the plugin
- [ ] I checked the **PR** once again

## Tests

Please start auto tests as follows:

- add a label <ins>swap test</ins> to start swap tests
- add a label <ins>withdraw test</ins> to start withdraw tests

You can skip these tests if you completely sure that your changes aren't related to this functional

### Original issue
Part of #4820
#4817


### Video / screenshot proof
<!-- You can use Ctrl+V -->
