### PR TITLE
Show all enabled wallets after save or restore seed phrase

### DIFF
--- a/src/front/externalConfigs/mainnet-localhost.js
+++ b/src/front/externalConfigs/mainnet-localhost.js
@@ -140,4 +140,5 @@ window.buildOptions = {
   ],
   invoiceEnabled: true, // Allow create invoices
   showWalletBanners: true,
+  addAllEnabledWalletsAfterRestoreOrCreateSeedPhrase: false,
 }

--- a/src/front/shared/components/modals/SaveMnemonicModal/SaveMnemonicModal.tsx
+++ b/src/front/shared/components/modals/SaveMnemonicModal/SaveMnemonicModal.tsx
@@ -138,7 +138,7 @@ class SaveMnemonicModal extends React.Component<MnemonicModalProps, MnemonicModa
       window.location.assign(links.hashHome)
     }
 
-    const addAllEnabledWalletsAfterRestoreOrCreateSeedPhrase = config?.opts?.addAllEnabledWalletsAfterRestoreOrCreateSeedPhrase || true
+    const addAllEnabledWalletsAfterRestoreOrCreateSeedPhrase = config?.opts?.addAllEnabledWalletsAfterRestoreOrCreateSeedPhrase
 
     if (addAllEnabledWalletsAfterRestoreOrCreateSeedPhrase) {
       const currencies = getActivatedCurrencies()

--- a/src/front/shared/components/modals/SaveMnemonicModal/SaveMnemonicModal.tsx
+++ b/src/front/shared/components/modals/SaveMnemonicModal/SaveMnemonicModal.tsx
@@ -3,11 +3,11 @@ import { constants } from 'helpers'
 import actions from 'redux/actions'
 import { Link } from 'react-router-dom'
 import { connect } from 'redaction'
+import config from 'helpers/externalConfig'
+import { getActivatedCurrencies } from 'helpers/user'
 
 import cssModules from 'react-css-modules'
 
-import defaultStyles from '../Styles/default.scss'
-import styles from './SaveMnemonicModal.scss'
 import okSvg from 'shared/images/ok.svg'
 
 import Modal from 'components/modal/Modal/Modal'
@@ -17,6 +17,8 @@ import Copy from 'components/ui/Copy/Copy'
 
 import links from 'helpers/links'
 import feedback from 'shared/helpers/feedback'
+import styles from './SaveMnemonicModal.scss'
+import defaultStyles from '../Styles/default.scss'
 
 const langPrefix = `SaveMnemonicModal`
 const langLabels = defineMessages({
@@ -51,7 +53,14 @@ const langLabels = defineMessages({
   mnemonicDeleted: {
     id: `${langPrefix}_MnemoniceDeleted`,
     defaultMessage: `You have already saved your 12-words seed. {href}`,
-    values: { href: <Link to={links.savePrivateKeys}> <FormattedMessage id="MnemoniceDeleted_hrefText" defaultMessage="Try export private key" /></Link> }
+    values: { 
+      href: (
+        <Link to={links.savePrivateKeys}>
+          {' '}
+          <FormattedMessage id="MnemoniceDeleted_hrefText" defaultMessage="Try export private key" />
+        </Link>
+      ) 
+    },
   },
   beginNotice: {
     id: `${langPrefix}_BeginNotice`,
@@ -91,7 +100,7 @@ type MnemonicModalState = {
     user: { btcMultisigUserData },
   }) => ({
     btcData: btcMultisigUserData,
-  })
+  }),
 )
 @cssModules({ ...defaultStyles, ...styles }, { allowMultiple: true })
 class SaveMnemonicModal extends React.Component<MnemonicModalProps, MnemonicModalState> {
@@ -100,12 +109,10 @@ class SaveMnemonicModal extends React.Component<MnemonicModalProps, MnemonicModa
 
     const mnemonic = localStorage.getItem(constants.privateKeyNames.twentywords)
 
-    //@ts-ignore: strictNullChecks
-    const randomWords = (mnemonic !== '-') ? mnemonic.split(` `) : []
-    randomWords.sort(() => .5 - Math.random())
+    const randomWords = (mnemonic && mnemonic !== '-') ? mnemonic.split(` `) : []
+    randomWords.sort(() => 0.5 - Math.random())
 
-    //@ts-ignore: strictNullChecks
-    const words = (mnemonic !== '-') ? mnemonic.split(` `) : []
+    const words = (mnemonic && mnemonic !== '-') ? mnemonic.split(` `) : []
 
     this.state = {
       step: (mnemonic === '-') ? `removed` : `begin`,
@@ -116,10 +123,6 @@ class SaveMnemonicModal extends React.Component<MnemonicModalProps, MnemonicModa
       mnemonicInvalid: true,
       incorrectWord: false,
     }
-  }
-
-  handleGoToWallet = () => {
-    this.handleClose()
   }
 
   handleClose = () => {
@@ -133,6 +136,16 @@ class SaveMnemonicModal extends React.Component<MnemonicModalProps, MnemonicModa
       data.onClose()
     } else {
       window.location.assign(links.hashHome)
+    }
+
+    const addAllEnabledWalletsAfterRestoreOrCreateSeedPhrase = config?.opts?.addAllEnabledWalletsAfterRestoreOrCreateSeedPhrase || true
+
+    if (addAllEnabledWalletsAfterRestoreOrCreateSeedPhrase) {
+      const currencies = getActivatedCurrencies()
+      currencies.forEach((currency) => {
+        actions.core.markCoinAsVisible(currency.toUpperCase(), true)
+      })
+      localStorage.setItem(constants.localStorage.isWalletCreate, 'true')
     }
 
     actions.modals.close(name)
@@ -157,8 +170,6 @@ class SaveMnemonicModal extends React.Component<MnemonicModalProps, MnemonicModa
       mnemonic,
     } = this.state
 
-    let clickedWord
-
     const currentWord = enteredWords.length
 
     if (words[currentWord] !== randomWords[index]) {
@@ -175,9 +186,8 @@ class SaveMnemonicModal extends React.Component<MnemonicModalProps, MnemonicModa
       return
     }
 
-    clickedWord = randomWords.splice(index, 1)
-    enteredWords.push(clickedWord)
-
+    const clickedWord = randomWords.splice(index, 1)
+    enteredWords.push(...clickedWord)
 
     this.setState({
       randomWords,
@@ -199,7 +209,7 @@ class SaveMnemonicModal extends React.Component<MnemonicModalProps, MnemonicModa
   render() {
     const {
       name,
-      intl
+      intl,
     } = this.props
 
     const {
@@ -213,8 +223,13 @@ class SaveMnemonicModal extends React.Component<MnemonicModalProps, MnemonicModa
     } = this.state
 
     return (
-      //@ts-ignore: strictNullChecks
-      <Modal name={name} title={`${intl.formatMessage(langLabels.title)}`} onClose={this.handleClose} showCloseButton={true}>
+      // @ts-ignore: strictNullChecks
+      <Modal
+        name={name}
+        title={`${intl.formatMessage(langLabels.title)}`}
+        onClose={this.handleClose}
+        showCloseButton
+      >
         {step === `confirmMnemonic` && (
           <p styleName="notice mnemonicNotice">
             <FormattedMessage {...langLabels.enterMnemonicNotice} />
@@ -232,27 +247,31 @@ class SaveMnemonicModal extends React.Component<MnemonicModalProps, MnemonicModa
         )}
         <div>
           {step === `begin` && (
-            <Fragment>
+            <>
               <p styleName="notice mnemonicNotice">
-                <FormattedMessage {...langLabels.beginNotice} values={{
-                  br: <br />,
-                }}/>
+                <FormattedMessage
+                  {...langLabels.beginNotice}
+                  values={{
+                    br: <br />,
+                  }} />
               </p>
               <div styleName="buttonsHolder">
-                <Button blue onClick={() => {
-                  feedback.backup.started()
-                  this.setState({ step: `show` })
-                }}>
+                <Button
+                  blue
+                  onClick={() => {
+                    feedback.backup.started()
+                    this.setState({ step: `show` })
+                  }}>
                   <FormattedMessage {...langLabels.beginContinue} />
                 </Button>
                 <Button blue onClick={this.handleClose}>
                   <FormattedMessage {...langLabels.beginLater} />
                 </Button>
               </div>
-            </Fragment>
+            </>
           )}
           {step === `ready` && (
-            <Fragment>
+            <>
               <p styleName="notice mnemonicNotice">
                 <img styleName="finishImg" src={okSvg} alt="finish" />
                 <FormattedMessage {...langLabels.readySaveNotice} />
@@ -263,34 +282,30 @@ class SaveMnemonicModal extends React.Component<MnemonicModalProps, MnemonicModa
                   blue
                   onClick={this.handleFinish}
                 >
-                  <FormattedMessage id="WithdrawMSUserFinish" defaultMessage="Ready"/>
+                  <FormattedMessage id="WithdrawMSUserFinish" defaultMessage="Ready" />
                 </Button>
               </div>
-            </Fragment>
+            </>
           )}
           {step === `confirmMnemonic` && (
-            <Fragment>
+            <>
               <div styleName="highLevel">
                 <div styleName={`mnemonicView mnemonicEnter ${(incorrectWord) ? 'mnemonicError' : ''}`}>
                   {
-                    enteredWords.map((word, index) => {
-                      return (
-                        <button key={index} onClick={() => { }} className="ym-hide-content notranslate" translate="no">
-                          {word}
-                        </button>
-                      )
-                    })
+                    enteredWords.map((word, index) => (
+                      <button key={index} onClick={() => { }} className="ym-hide-content notranslate" translate="no" type="button">
+                        {word}
+                      </button>
+                    ))
                   }
                 </div>
                 <div styleName="mnemonicWords">
                   {
-                    randomWords.map((word, index) => {
-                      return (
-                        <button key={index} onClick={() => this.handleClickWord(index)} className="ym-hide-content notranslate" translate="no">
-                          {word}
-                        </button>
-                      )
-                    })
+                    randomWords.map((word, index) => (
+                      <button key={index} onClick={() => this.handleClickWord(index)} className="ym-hide-content notranslate" translate="no" type="button">
+                        {word}
+                      </button>
+                    ))
                   }
                 </div>
               </div>
@@ -301,30 +316,28 @@ class SaveMnemonicModal extends React.Component<MnemonicModalProps, MnemonicModa
                   disabled={mnemonicInvalid}
                   onClick={this.handleFinish}
                 >
-                  <FormattedMessage id="WithdrawMSUserFinish" defaultMessage="Ready"/>
+                  <FormattedMessage id="WithdrawMSUserFinish" defaultMessage="Ready" />
                 </Button>
               </div>
-            </Fragment>
+            </>
           )}
           {step === `show` && (
-            <Fragment>
+            <>
               <div styleName="highLevel">
                 <div styleName="mnemonicView" className="ym-hide-content notranslate" translate="no">
                   {
-                    words.map((word, index) => {
-                      return (
-                        <div key={index} styleName='mnemonicViewWordWrapper'>
-                          <div>
-                            <span styleName="wordIndex">{(index + 1)}</span>
-                            <span>{word}</span>
-                          </div>
-                          {
-                            /* space for correct copy-paste */
-                            index + 1 !== words.length && ' '
-                          }
+                    words.map((word, index) => (
+                      <div key={index} styleName="mnemonicViewWordWrapper">
+                        <div>
+                          <span styleName="wordIndex">{(index + 1)}</span>
+                          <span>{word}</span>
                         </div>
-                      )
-                    })
+                        {
+                          /* space for correct copy-paste */
+                          index + 1 !== words.length && ' '
+                        }
+                      </div>
+                    ))
                   }
                 </div>
                 <p styleName="notice mnemonicNotice">
@@ -337,16 +350,16 @@ class SaveMnemonicModal extends React.Component<MnemonicModalProps, MnemonicModa
               <div styleName="mnemonicButtonsWrapper">
                 <Copy text={mnemonic}>
                   <Button brand>
-                    <FormattedMessage id="FeeControler49" defaultMessage="Copy"/>
+                    <FormattedMessage id="FeeControler49" defaultMessage="Copy" />
                   </Button>
                 </Copy>
                 <div styleName="continueBtnWrapper">
                   <Button brand onClick={this.handleGoToConfirm}>
-                    <FormattedMessage id="createWalletButton1" defaultMessage="Continue"/>
+                    <FormattedMessage id="createWalletButton1" defaultMessage="Continue" />
                   </Button>
                 </div>
               </div>
-            </Fragment>
+            </>
           )}
         </div>
       </Modal>

--- a/src/front/shared/helpers/externalConfig.ts
+++ b/src/front/shared/helpers/externalConfig.ts
@@ -150,12 +150,14 @@ const externalConfig = () => {
     config.opts.ui.menu.after = window.SO_MenuItemsAfter
   }
 
-  if (window
-    && window.SO_disableInternalWallet
-    && window.SO_disableInternalWallet
-  ) {
+  if (window?.SO_disableInternalWallet) {
     config.opts.ui.disableInternalWallet = window.SO_disableInternalWallet
   }
+
+  if (window?.SO_addAllEnabledWalletsAfterRestoreOrCreateSeedPhrase) {
+    config.opts.addAllEnabledWalletsAfterRestoreOrCreateSeedPhrase = window.SO_addAllEnabledWalletsAfterRestoreOrCreateSeedPhrase
+  }
+
   if (window
     && window.SO_fiatBuySupperted
     && window.SO_fiatBuySupperted.length

--- a/src/front/shared/helpers/user.ts
+++ b/src/front/shared/helpers/user.ts
@@ -47,12 +47,10 @@ export const getActivatedCurrencies = () => {
     currencies.push('NEXT')
   }
 
-  Object.keys(TOKEN_STANDARDS).forEach((key) => {
-    const standard = TOKEN_STANDARDS[key].standard
+  Object.keys(TOKEN_STANDARDS).forEach((standardKey) => {
+    Object.keys(externalConfig[standardKey]).forEach((token) => {
 
-    Object.keys(externalConfig[standard]).forEach((token) => {
-
-      const baseCurrency = TOKEN_STANDARDS[standard].currency.toUpperCase()
+      const baseCurrency = TOKEN_STANDARDS[standardKey].currency.toUpperCase()
       const tokenName = token.toUpperCase()
       const tokenValue = `{${baseCurrency}}${tokenName}`
 

--- a/src/front/shared/localisation/de.json
+++ b/src/front/shared/localisation/de.json
@@ -4077,6 +4077,7 @@
     "id": "BTCMS_SaveMnemonicButton",
     "message": "Geheime Phrase speichern",
     "files": [
+      "src/front/shared/pages/CreateWallet/CreateWallet.tsx",
       "src/front/shared/pages/Exchange/QuickSwap/UserInfo.tsx",
       "src/front/shared/pages/Marketmaker/MarketmakerSettings.tsx",
       "src/front/shared/pages/Multisign/Btc/Btc.tsx"

--- a/src/front/shared/localisation/en.json
+++ b/src/front/shared/localisation/en.json
@@ -4062,6 +4062,7 @@
     "id": "BTCMS_SaveMnemonicButton",
     "message": "Save secret phrase",
     "files": [
+      "src/front/shared/pages/CreateWallet/CreateWallet.tsx",
       "src/front/shared/pages/Exchange/QuickSwap/UserInfo.tsx",
       "src/front/shared/pages/Marketmaker/MarketmakerSettings.tsx",
       "src/front/shared/pages/Multisign/Btc/Btc.tsx"

--- a/src/front/shared/localisation/es.json
+++ b/src/front/shared/localisation/es.json
@@ -3886,6 +3886,7 @@
     "id": "BTCMS_SaveMnemonicButton",
     "message": "Guardar frase secreta",
     "files": [
+      "src/front/shared/pages/CreateWallet/CreateWallet.tsx",
       "src/front/shared/pages/Exchange/QuickSwap/UserInfo.tsx",
       "src/front/shared/pages/Marketmaker/MarketmakerSettings.tsx",
       "src/front/shared/pages/Multisign/Btc/Btc.tsx"

--- a/src/front/shared/localisation/ko.json
+++ b/src/front/shared/localisation/ko.json
@@ -4062,6 +4062,7 @@
     "id": "BTCMS_SaveMnemonicButton",
     "message": "씨드 문장 저장",
     "files": [
+      "src/front/shared/pages/CreateWallet/CreateWallet.tsx",
       "src/front/shared/pages/Exchange/QuickSwap/UserInfo.tsx",
       "src/front/shared/pages/Marketmaker/MarketmakerSettings.tsx",
       "src/front/shared/pages/Multisign/Btc/Btc.tsx"

--- a/src/front/shared/localisation/nl.json
+++ b/src/front/shared/localisation/nl.json
@@ -3931,6 +3931,7 @@
     "id": "BTCMS_SaveMnemonicButton",
     "message": "Save secret phrase",
     "files": [
+      "src/front/shared/pages/CreateWallet/CreateWallet.tsx",
       "src/front/shared/pages/Exchange/QuickSwap/UserInfo.tsx",
       "src/front/shared/pages/Marketmaker/MarketmakerSettings.tsx",
       "src/front/shared/pages/Multisign/Btc/Btc.tsx"

--- a/src/front/shared/localisation/pl.json
+++ b/src/front/shared/localisation/pl.json
@@ -3943,6 +3943,7 @@
     "id": "BTCMS_SaveMnemonicButton",
     "message": "Save secret phrase",
     "files": [
+      "src/front/shared/pages/CreateWallet/CreateWallet.tsx",
       "src/front/shared/pages/Exchange/QuickSwap/UserInfo.tsx",
       "src/front/shared/pages/Marketmaker/MarketmakerSettings.tsx",
       "src/front/shared/pages/Multisign/Btc/Btc.tsx"

--- a/src/front/shared/localisation/pt.json
+++ b/src/front/shared/localisation/pt.json
@@ -4062,6 +4062,7 @@
     "id": "BTCMS_SaveMnemonicButton",
     "message": "Salvar frase secreta",
     "files": [
+      "src/front/shared/pages/CreateWallet/CreateWallet.tsx",
       "src/front/shared/pages/Exchange/QuickSwap/UserInfo.tsx",
       "src/front/shared/pages/Marketmaker/MarketmakerSettings.tsx",
       "src/front/shared/pages/Multisign/Btc/Btc.tsx"

--- a/src/front/shared/localisation/ru.json
+++ b/src/front/shared/localisation/ru.json
@@ -4066,6 +4066,7 @@
     "id": "BTCMS_SaveMnemonicButton",
     "message": "Сохранить секретную фразу",
     "files": [
+      "src/front/shared/pages/CreateWallet/CreateWallet.tsx",
       "src/front/shared/pages/Exchange/QuickSwap/UserInfo.tsx",
       "src/front/shared/pages/Marketmaker/MarketmakerSettings.tsx",
       "src/front/shared/pages/Multisign/Btc/Btc.tsx"

--- a/src/front/shared/pages/CreateWallet/CreateWallet.tsx
+++ b/src/front/shared/pages/CreateWallet/CreateWallet.tsx
@@ -15,6 +15,7 @@ import metamask from 'helpers/metamask'
 import { localisedUrl } from 'helpers/locale'
 
 import Tooltip from 'components/ui/Tooltip/Tooltip'
+import Button from 'shared/components/controls/Button/Button'
 
 import { constants, localStorage } from 'helpers'
 import CloseIcon from 'components/ui/CloseIcon/CloseIcon'
@@ -23,6 +24,7 @@ import StepsWrapper from './Steps/StepsWrapper'
 import styles from './CreateWallet.scss'
 
 const noInternalWallet = !!(config?.opts?.ui?.disableInternalWallet)
+const addAllEnabledWalletsAfterRestoreOrCreateSeedPhrase = !!(config?.opts?.addAllEnabledWalletsAfterRestoreOrCreateSeedPhrase || true)
 
 function CreateWallet(props) {
   const {
@@ -95,6 +97,10 @@ function CreateWallet(props) {
     }
     localStorage.setItem(constants.localStorage.isWalletCreate, true)
     goHome()
+  }
+
+  const handleShowMnemonic = () => {
+    actions.modals.open(constants.modals.SaveMnemonicModal)
   }
 
   const handleRestoreMnemonic = () => {
@@ -258,7 +264,7 @@ function CreateWallet(props) {
         <div styleName="buttonWrapper">
           {!noInternalWallet && (
             <div>
-              <button onClick={handleRestoreMnemonic}>
+              <button onClick={handleRestoreMnemonic} type="button">
                 <FormattedMessage id="ImportKeys_RestoreMnemonic" defaultMessage="Restore from 12-word seed" />
               </button>
               &nbsp;
@@ -282,7 +288,7 @@ function CreateWallet(props) {
           )}
           {!metamask.isConnected() && (
             <div>
-              <button onClick={handleConnectWallet}>
+              <button onClick={handleConnectWallet} type="button">
                 {web3Icon && (
                   <img styleName="connectWalletIcon" src={web3Icon} />
                 )}
@@ -299,16 +305,31 @@ function CreateWallet(props) {
           )}
         </div>
 
-        <StepsWrapper
-          step={step}
-          forcedCurrencyData={forcedCurrencyData}
-          error={error}
-          onClick={validate}
-          setError={setError}
-          btcData={btcData}
-          currenciesForSecondStep={currencies}
-          showPinContent={hash === '#pin'}
-        />
+        {
+          addAllEnabledWalletsAfterRestoreOrCreateSeedPhrase
+            ? (
+              <div style={{ display: 'flex', justifyContent: 'center', width: '60%', margin: 'auto' }}>
+                <Button blue fullWidth onClick={handleShowMnemonic}>
+                  <FormattedMessage
+                    id="BTCMS_SaveMnemonicButton"
+                    defaultMessage="Save secret phrase"
+                  />
+                </Button>
+              </div>
+            )
+            : (
+              <StepsWrapper
+                step={step}
+                forcedCurrencyData={forcedCurrencyData}
+                error={error}
+                onClick={validate}
+                setError={setError}
+                btcData={btcData}
+                currenciesForSecondStep={currencies}
+                showPinContent={hash === '#pin'}
+              />
+            )
+        }
       </div>
     </div>
   )

--- a/src/front/shared/pages/CreateWallet/CreateWallet.tsx
+++ b/src/front/shared/pages/CreateWallet/CreateWallet.tsx
@@ -24,7 +24,7 @@ import StepsWrapper from './Steps/StepsWrapper'
 import styles from './CreateWallet.scss'
 
 const noInternalWallet = !!(config?.opts?.ui?.disableInternalWallet)
-const addAllEnabledWalletsAfterRestoreOrCreateSeedPhrase = !!(config?.opts?.addAllEnabledWalletsAfterRestoreOrCreateSeedPhrase || true)
+const addAllEnabledWalletsAfterRestoreOrCreateSeedPhrase = !!config?.opts?.addAllEnabledWalletsAfterRestoreOrCreateSeedPhrase
 
 function CreateWallet(props) {
   const {

--- a/src/front/shared/pages/Wallet/CurrenciesList.tsx
+++ b/src/front/shared/pages/Wallet/CurrenciesList.tsx
@@ -9,12 +9,15 @@ import {
 import actions from 'redux/actions'
 
 import Button from 'components/controls/Button/Button'
+import Tooltip from 'shared/components/ui/Tooltip/Tooltip'
 import Table from 'components/tables/Table/Table'
 import ConnectWalletModal from 'components/modals/ConnectWalletModal/ConnectWalletModal'
 import Slider from './WallerSlider'
 import Row from './Row/Row'
 import styles from './Wallet.scss'
 
+const addAllEnabledWalletsAfterRestoreOrCreateSeedPhrase = config?.opts?.addAllEnabledWalletsAfterRestoreOrCreateSeedPhrase
+const noInternalWallet = config?.opts?.ui?.disableInternalWallet
 const isWidgetBuild = config && config.isWidget
 
 type CurrenciesListProps = {
@@ -33,6 +36,10 @@ function CurrenciesList(props: CurrenciesListProps) {
 
   const openAddCustomTokenModal = () => {
     actions.modals.open(constants.modals.AddCustomToken)
+  }
+
+  const handleRestoreMnemonic = () => {
+    actions.modals.open(constants.modals.RestoryMnemonicWallet)
   }
 
   const showAssets = !(config?.opts?.ui?.disableInternalWallet)
@@ -56,6 +63,7 @@ function CurrenciesList(props: CurrenciesListProps) {
               defaultMessage="Here you can safely store, send and receive assets"
             />
           </div>
+
           <Table
             className={`${styles.walletTable} data-tut-address`}
             rows={tableRows}
@@ -68,12 +76,36 @@ function CurrenciesList(props: CurrenciesListProps) {
             )}
           />
           <div styleName="addCurrencyBtnWrapper">
-            <Button id="addAssetBtn" onClick={goToСreateWallet} transparent fullWidth>
-              <FormattedMessage id="addAsset" defaultMessage="Add currency" />
-            </Button>
             <Button id="addCustomTokenBtn" onClick={openAddCustomTokenModal} transparent fullWidth>
               <FormattedMessage id="addCustomToken" defaultMessage="Add custom token" />
             </Button>
+            {addAllEnabledWalletsAfterRestoreOrCreateSeedPhrase && !noInternalWallet && (
+              <Button onClick={handleRestoreMnemonic} small link>
+                <FormattedMessage id="ImportKeys_RestoreMnemonic" defaultMessage="Restore from 12-word seed" />
+                &nbsp;
+                <Tooltip id="ImportKeys_RestoreMnemonic_tooltip">
+                  <span>
+                    <FormattedMessage
+                      id="ImportKeys_RestoreMnemonic_Tooltip"
+                      defaultMessage="12-word backup phrase"
+                    />
+                    <br />
+                    <br />
+                    <div styleName="alertTooltipWrapper">
+                      <FormattedMessage
+                        id="ImportKeys_RestoreMnemonic_Tooltip_withBalance"
+                        defaultMessage="Please, be causious!"
+                      />
+                    </div>
+                  </span>
+                </Tooltip>
+              </Button>
+            )}
+            {!addAllEnabledWalletsAfterRestoreOrCreateSeedPhrase && (
+              <Button id="addAssetBtn" onClick={goToСreateWallet} transparent fullWidth>
+                <FormattedMessage id="addAsset" defaultMessage="Add currency" />
+              </Button>
+            )}
           </div>
         </>
       )}

--- a/src/front/shared/pages/Wallet/Wallet.scss
+++ b/src/front/shared/pages/Wallet/Wallet.scss
@@ -301,3 +301,10 @@
     }
   }
 }
+
+.alertTooltipWrapper {
+  font-size: 0.8em;
+  padding: 0.3em 0.5em;
+  background: rgba(var(--color-bad), 0.6);
+  border-radius: 2px;
+}


### PR DESCRIPTION
## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/swaponline/MultiCurrencyWallet/blob/master/docs/CONTRIBUTING.md) guide
- [ ] Good naming (as clear and simple as possible)
- [ ] Correct behavior if external API endpoints are down, return 404, 504 (or no answer), 401 errors (ddos simulation)
- [ ] I tested desktop/mobile resolution
- [ ] I tested light/dark theme
- [ ] I tested different languages
- [ ] I checked the functionality once again (**AFFECT MONEY**)
- [ ] I checked the work on the Testnet
- [ ] I checked the work on the Mainnet
- [ ] I checked the work in the plugin
- [ ] I checked the **PR** once again

## Tests

Please start auto tests as follows:

- add a label <ins>swap test</ins> to start swap tests
- add a label <ins>withdraw test</ins> to start withdraw tests

You can skip these tests if you completely sure that your changes aren't related to this functional

### Original issue
<!-- Type number -->
#5027 

### Video / screenshot proof
<!-- You can use Ctrl+V -->
