### PR TITLE
Disable next coin by default

### DIFF
--- a/src/front/externalConfigs/mainnet-localhost.js
+++ b/src/front/externalConfigs/mainnet-localhost.js
@@ -104,7 +104,7 @@ window.buildOptions = {
     movr: true,
     one: true,
     ghost: true,
-    next: true,
+    next: false,
   },
   blockchainSwapEnabled: {
     btc: true,

--- a/src/front/externalConfigs/swaponline.github.io.js
+++ b/src/front/externalConfigs/swaponline.github.io.js
@@ -59,7 +59,7 @@ window.buildOptions = {
     movr: true,
     one: true,
     ghost: true,
-    next: true,
+    next: false,
   },
   blockchainSwapEnabled: {
     btc: true,

--- a/src/front/externalConfigs/testnet-default.js
+++ b/src/front/externalConfigs/testnet-default.js
@@ -140,7 +140,7 @@ window.buildOptions = {
     movr: true,
     one: true,
     ghost: true,
-    next: true,
+    next: false,
   },
   blockchainSwapEnabled: {
     btc: true,
@@ -154,7 +154,7 @@ window.buildOptions = {
     movr: false,
     one: false,
     ghost: false,
-    next: true,
+    next: false,
   },
   defaultExchangePair: {
     buy: '{eth}usdt',

--- a/src/front/shared/helpers/externalConfig.ts
+++ b/src/front/shared/helpers/externalConfig.ts
@@ -50,7 +50,7 @@ const externalConfig = () => {
       one: true,
       btc: true,
       ghost: true,
-      next: true,
+      next: false,
     },
     blockchainSwapEnabled: {
       btc: true,
@@ -64,7 +64,7 @@ const externalConfig = () => {
       movr: false,
       one: false,
       ghost: true,
-      next: true,
+      next: false,
     },
     createWalletCoinsOrder: false,
     buyFiatSupported: ['eth', 'matic'],
@@ -244,9 +244,9 @@ const externalConfig = () => {
     config.opts.blockchainSwapEnabled.ghost = false
   }
 
-  if (window && window.CUR_NEXT_DISABLED === true) {
-    config.opts.curEnabled.next = false
-    config.opts.blockchainSwapEnabled.next = false
+  if (window && window.CUR_NEXT_DISABLED === false) {
+    config.opts.curEnabled.next = true
+    config.opts.blockchainSwapEnabled.next = true
   }
 
   if (window && window.CUR_ETH_DISABLED === true) {


### PR DESCRIPTION
## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/swaponline/MultiCurrencyWallet/blob/master/docs/CONTRIBUTING.md) guide
- [ ] Good naming (as clear and simple as possible)
- [ ] Correct behavior if external API endpoints are down, return 404, 504 (or no answer), 401 errors (ddos simulation)
- [ ] I tested desktop/mobile resolution
- [ ] I tested light/dark theme
- [ ] I tested different languages
- [ ] I checked the functionality once again (**AFFECT MONEY**)
- [ ] I checked the work on the Testnet
- [ ] I checked the work on the Mainnet
- [ ] I checked the work in the plugin
- [ ] I checked the **PR** once again

## Tests

Please start auto tests as follows:

- add a label <ins>swap test</ins> to start swap tests
- add a label <ins>withdraw test</ins> to start withdraw tests

You can skip these tests if you completely sure that your changes aren't related to this functional

### Original issue
<!-- Type number -->
#5061

### Video / screenshot proof
<!-- You can use Ctrl+V -->
