### PR TITLE
dont show fiat for token invoice if cource not enabled

### DIFF
--- a/src/front/shared/components/modals/InvoiceModal/InvoiceModal.tsx
+++ b/src/front/shared/components/modals/InvoiceModal/InvoiceModal.tsx
@@ -94,7 +94,7 @@ class InvoiceModal extends React.Component<InvoiceModalProps, InvoiceModalState>
     const { infoAboutCurrency } = walletData
     const multiplier = infoAboutCurrency && infoAboutCurrency.price_fiat
       ? infoAboutCurrency.price_fiat
-      : 1
+      : 0
 
     this.state = {
       isToken,
@@ -273,6 +273,7 @@ class InvoiceModal extends React.Component<InvoiceModalProps, InvoiceModalState>
         tokenKey,
       },
       walletData,
+      multiplier,
     } = this.state
     const currency = ((tokenKey) || currencyOriginal).toUpperCase()
 
@@ -392,15 +393,17 @@ class InvoiceModal extends React.Component<InvoiceModalProps, InvoiceModalState>
                   <FormattedMessage id="orders102" defaultMessage="Amount" />
                 </span>
               </FieldLabel>
-              <span styleName="amountTooltip">
-                {
-                  new BigNumber(amount).isGreaterThan(0)
-                    ? selectedValue === currency
-                      ? `~ ${fiatAmount} USD`
-                      : `~ ${amount} ${currency}`
-                    : ''
-                }
-              </span>
+              {!multiplier.isEqualTo(0) && (
+                <span styleName="amountTooltip">
+                  {
+                    new BigNumber(amount).isGreaterThan(0)
+                      ? selectedValue === currency
+                        ? `~ ${fiatAmount} USD`
+                        : `~ ${amount} ${currency}`
+                      : ''
+                  }
+                </span>
+              )}
               <Input
                 className={ownStyle.input}
                 placeholder={intl.formatMessage(localeLabel.amountPlaceholder)}
@@ -417,6 +420,7 @@ class InvoiceModal extends React.Component<InvoiceModalProps, InvoiceModalState>
                 onSelect={this.handleBuyCurrencySelect}
                 selectedItemRender={(item) => item.fullTitle}
                 currencies={curList}
+                disabled={multiplier.isEqualTo(0)}
               />
             </div>
             <div styleName="highLevel">

--- a/src/front/shared/components/ui/CurrencySelect/CurrencySelect.tsx
+++ b/src/front/shared/components/ui/CurrencySelect/CurrencySelect.tsx
@@ -11,6 +11,7 @@ const CurrencySelect = (props) => {
     name = '',
     placeholder = '',
     selectedItemRender,
+    disabled = false
   } = props
 
   const defaultRenderSelected = (item) => <Option {...item} />
@@ -24,6 +25,7 @@ const CurrencySelect = (props) => {
       selectedItemRender={usedSelectedItemRender}
       itemRender={defaultRenderSelected}
       onSelect={onSelect}
+      disabled={disabled}
       name={name}
       role="SelectCurrency"
     />

--- a/src/front/shared/components/ui/DropDown/index.tsx
+++ b/src/front/shared/components/ui/DropDown/index.tsx
@@ -19,6 +19,7 @@ type DropDownProps = {
   arrowSide?: string
   disableSearch?: boolean
   dontScroll?: boolean
+  disabled?: boolean
   role?: string
 }
 
@@ -51,6 +52,9 @@ export default class DropDown extends Component<DropDownProps, DropDownState> {
   }
 
   toggleOpen = () => {
+    const { disabled } = this.props
+    if (disabled) return
+
     this.setState(() => ({
       optionToggleIsOpen: true,
     }))
@@ -126,6 +130,7 @@ export default class DropDown extends Component<DropDownProps, DropDownState> {
       arrowSide,
       role,
       itemRender,
+      disabled,
     } = this.props
 
     const { optionToggleIsOpen, inputValue } = this.state
@@ -163,7 +168,7 @@ export default class DropDown extends Component<DropDownProps, DropDownState> {
             onClick={moreThenOneOption ? this.toggleOpen : () => null}
           >
             {/* Drop Down arrow */}
-            {moreThenOneOption && <div styleName={`arrow ${arrowSide === 'left' ? 'left' : ''}`} />}
+            {moreThenOneOption && !disabled && <div styleName={`arrow ${arrowSide === 'left' ? 'left' : ''}`} />}
 
             {/* Search input */}
             {optionToggleIsOpen && !disableSearch ? (


### PR DESCRIPTION
## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/swaponline/MultiCurrencyWallet/blob/master/docs/CONTRIBUTING.md) guide
- [ ] Good naming (as clear and simple as possible)
- [ ] Correct behavior if external API endpoints are down, return 404, 504 (or no answer), 401 errors (ddos simulation)
- [ ] I tested desktop/mobile resolution
- [ ] I tested light/dark theme
- [ ] I tested different languages
- [ ] I checked the functionality once again (**AFFECT MONEY**)
- [ ] I checked the work on the Testnet
- [ ] I checked the work on the Mainnet
- [ ] I checked the work in the plugin
- [ ] I checked the **PR** once again

## Tests

Please start auto tests as follows:

- add a label <ins>swap test</ins> to start swap tests
- add a label <ins>withdraw test</ins> to start withdraw tests

You can skip these tests if you completely sure that your changes aren't related to this functional

### Original issue
<!-- Type number -->
https://github.com/swaponline/MultiCurrencyWallet/issues/5090

### Video / screenshot proof
<!-- You can use Ctrl+V -->
