### PR TITLE
Add allowing to approve token with 0x

### DIFF
--- a/src/front/shared/pages/Exchange/QuickSwap/Footer.tsx
+++ b/src/front/shared/pages/Exchange/QuickSwap/Footer.tsx
@@ -42,6 +42,7 @@ function Footer(props: FooterProps) {
     onInputDataChange,
   } = props
   const {
+    blockReason,
     network,
     spendedAmount,
     fromWallet,
@@ -226,7 +227,7 @@ function Footer(props: FooterProps) {
 
   const doNotMakeApiRequest = isApiRequestBlocking()
 
-  const commonBlockReasons = isPending || (!!error && !error.message?.match('transfer amount exceeds allowance'))
+  const commonBlockReasons = isPending || (blockReason !== BlockReasons.NotApproved && !!error && (!error.message?.match('transfer amount exceeds allowance')))
   const formFilled = !!spendedAmount && !!receivedAmount
 
   const approvingDoesNotMakeSense =

--- a/src/front/shared/pages/Exchange/QuickSwap/index.tsx
+++ b/src/front/shared/pages/Exchange/QuickSwap/index.tsx
@@ -470,6 +470,7 @@ class QuickSwap extends PureComponent<IUniversalObj, ComponentState> {
     const possibleNoLiquidity = JSON.stringify(error)?.match(/INSUFFICIENT_ASSET_LIQUIDITY/)
     const insufficientSlippage = JSON.stringify(error)?.match(/IncompleteTransformERC20Error/)
     const notEnoughBalance = error.message?.match(/(N|n)ot enough .* balance/)
+    const notApproved = JSON.stringify(error)?.match(/SenderNotAuthorizedError/)
 
     if (possibleNoLiquidity) {
       this.setBlockReason(BlockReasons.NoLiquidity)
@@ -479,6 +480,8 @@ class QuickSwap extends PureComponent<IUniversalObj, ComponentState> {
       this.setBlockReason(BlockReasons.NoBalance)
     } else if (liquidityErrorMessage) {
       this.setBlockReason(BlockReasons.Liquidity)
+    } else if (notApproved) {
+      this.setBlockReason(BlockReasons.NotApproved)
     } else {
       this.setBlockReason(BlockReasons.Unknown)
 

--- a/src/front/shared/pages/Exchange/QuickSwap/types.ts
+++ b/src/front/shared/pages/Exchange/QuickSwap/types.ts
@@ -49,6 +49,7 @@ export enum BlockReasons {
   NoBaseCurrencyBalance,
   Liquidity,
   PairDoesNotExist,
+  NotApproved,
   Unknown,
 }
 


### PR DESCRIPTION
## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/swaponline/MultiCurrencyWallet/blob/master/docs/CONTRIBUTING.md) guide
- [ ] Good naming (as clear and simple as possible)
- [ ] Correct behavior if external API endpoints are down, return 404, 504 (or no answer), 401 errors (ddos simulation)
- [ ] I tested desktop/mobile resolution
- [ ] I tested light/dark theme
- [ ] I tested different languages
- [ ] I checked the functionality once again (**AFFECT MONEY**)
- [ ] I checked the work on the Testnet
- [ ] I checked the work on the Mainnet
- [ ] I checked the work in the plugin
- [ ] I checked the **PR** once again

## Tests

Please start auto tests as follows:

- add a label <ins>swap test</ins> to start swap tests
- add a label <ins>withdraw test</ins> to start withdraw tests

You can skip these tests if you completely sure that your changes aren't related to this functional

### Original issue
<!-- Type number -->
#

### Video / screenshot proof
<!-- You can use Ctrl+V -->
