### PR TITLE
Use Primary color of the app for notifyBlockSaveKeys banner

### DIFF
--- a/src/front/shared/pages/Wallet/WallerSlider/index.tsx
+++ b/src/front/shared/pages/Wallet/WallerSlider/index.tsx
@@ -223,7 +223,6 @@ class WallerSlider extends React.Component<WallerSliderProps, WallerSliderState>
                 <div className="swiper-slide">
                   <NotifyBlock
                     className="notifyBlockSaveKeys"
-                    background="6144e5"
                     icon={security}
                     text={
                       <FormattedMessage


### PR DESCRIPTION
## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/swaponline/MultiCurrencyWallet/blob/master/docs/CONTRIBUTING.md) guide
- [ ] Good naming (as clear and simple as possible)
- [ ] Correct behavior if external API endpoints are down, return 404, 504 (or no answer), 401 errors (ddos simulation)
- [ ] I tested desktop/mobile resolution
- [ ] I tested light/dark theme
- [ ] I tested different languages
- [ ] I checked the functionality once again (**AFFECT MONEY**)
- [ ] I checked the work on the Testnet
- [ ] I checked the work on the Mainnet
- [ ] I checked the work in the plugin
- [ ] I checked the **PR** once again

## Tests

Please start auto tests as follows:

- add a label <ins>swap test</ins> to start swap tests
- add a label <ins>withdraw test</ins> to start withdraw tests

You can skip these tests if you completely sure that your changes aren't related to this functional

### Original issue
<!-- Type number -->
#

### Video / screenshot proof
<!-- You can use Ctrl+V -->
