### PR TITLE
Fix Etherscan V1 deprecation: broken V2 URLs cause NODE IS DOWN error

### DIFF
--- a/src/core/simple/src/instances/ethereum.ts
+++ b/src/core/simple/src/instances/ethereum.ts
@@ -45,8 +45,8 @@ class Ethereum {
     }
 
     this.etherscan = _network === 'testnet'
-      ? `https://api-rinkeby.etherscan.io`
-      : `https://api.etherscan.io`
+      ? `https://api-sepolia.etherscan.io/api`
+      : `https://api.etherscan.io/v2/api?chainid=1`
   }
 
   fetchBalance(address) {
@@ -68,7 +68,7 @@ class Ethereum {
   fetchTokenBalance(address, tokenAddress, decimals) {
     const TEN = new BigNumber(10)
     const base = TEN.pow(decimals) // 1e18 usually
-    const url = `${this.etherscan}/api?module=account&action=tokenbalance&contractaddress=${tokenAddress}&address=${address}&apikey=${ETHERSCAN_APIKEY}`
+    const url = `${this.etherscan}&module=account&action=tokenbalance&contractaddress=${tokenAddress}&address=${address}&apikey=${ETHERSCAN_APIKEY}`
 
     // cache 10 seconds
     // query request

--- a/src/front/config/mainnet/feeRates.js
+++ b/src/front/config/mainnet/feeRates.js
@@ -1,8 +1,8 @@
 import api from './api'
 
 export default {
-  eth: `${api.etherscan}?module=proxy&action=eth_gasPrice&apikey=${api.etherscan_ApiKey}`,
-  bsc: `${api.bscscan}?module=proxy&action=eth_gasPrice&apikey=${api.bscscan_ApiKey}`,
-  matic: `${api.maticscan}?module=proxy&action=eth_gasPrice&apikey=${api.polygon_ApiKey}`,
+  eth: `${api.etherscan}&module=proxy&action=eth_gasPrice&apikey=${api.etherscan_ApiKey}`,
+  bsc: `${api.bscscan}&module=proxy&action=eth_gasPrice&apikey=${api.bscscan_ApiKey}`,
+  matic: `${api.maticscan}&module=proxy&action=eth_gasPrice&apikey=${api.polygon_ApiKey}`,
   btc: 'https://wiki.swaponline.io/blockcyper.php',
 }


### PR DESCRIPTION
## Problem

Clients are getting **NODE IS DOWN** error, and clicking **?** opens a browser window with:
> *"You are using a deprecated V1 endpoint, switch to Etherscan API V2"*

## Root Cause

### 1. Double `?` in `feeRates.js`

`api.etherscan` already ends with `?chainid=1` (V2 format), but the code appended another `?`, producing malformed URLs:

```
# Broken → gas price fetch fails → balance error → NODE IS DOWN
https://api.etherscan.io/v2/api?chainid=1?module=proxy&action=eth_gasPrice&apikey=...

# Fixed
https://api.etherscan.io/v2/api?chainid=1&module=proxy&action=eth_gasPrice&apikey=...
```

Same issue for BSC and MATIC.

### 2. V1 endpoint in `src/core/simple/src/instances/ethereum.ts`

Core bot instance still used `https://api.etherscan.io/api` (V1) and decommissioned Rinkeby testnet.

## Changes (2 files only)

- `src/front/config/mainnet/feeRates.js`: `?` → `&` for ETH, BSC, MATIC gas price URLs
- `src/core/simple/src/instances/ethereum.ts`: V1 → V2 endpoint, Rinkeby → Sepolia, fix URL concatenation

Preview: https://pr5263.mcw2.wpmix.net

🤖 Generated with [Claude Code](https://claude.com/claude-code)