### PR TITLE
Add PR Preview Deploy workflow (Cloudflare Pages)

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,91 @@
+name: PR Preview Deploy
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18.20.0'
+          cache: 'npm'
+
+      - name: Install dependencies
+        uses: bahmutov/npm-install@v1
+        with:
+          useLockFile: false
+
+      - name: Build mainnet
+        run: |
+          NODE_ENV=production CONFIG=mainnet.prod node --max-old-space-size=8192 ./src/front/bin/compile
+        env:
+          DEBUG: 'app:*'
+
+      - name: Deploy to Cloudflare Pages
+        id: deploy
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy build-mainnet --project-name=mcw-preview --branch=pr-${{ github.event.pull_request.number }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Comment preview URL on PR
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const deployUrl = '${{ steps.deploy.outputs.deployment-url }}';
+            const sha = context.payload.pull_request.head.sha.slice(0, 7);
+
+            const marker = '<!-- pr-preview-bot -->';
+            const body = [
+              marker,
+              '## Preview Deploy',
+              '',
+              '| | |',
+              '|---|---|',
+              `| **URL** | ${deployUrl} |`,
+              `| **Commit** | \`${sha}\` |`,
+              '| **Status** | ✅ Ready |',
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+            }


### PR DESCRIPTION
## Summary

Adds GitHub Actions workflow for automatic PR preview deployments via Cloudflare Pages.

- Uses `pull_request_target` trigger so secrets are accessible for PRs from forks
- Builds mainnet bundle on each PR open/update
- Deploys to `mcw-preview.pages.dev` with branch `pr-{number}`
- Posts/updates a comment on the PR with the preview URL

## Prerequisites

Repository secrets required (already added):
- `CLOUDFLARE_API_TOKEN`
- `CLOUDFLARE_ACCOUNT_ID`

Cloudflare Pages project: `mcw-preview` (already created)

🤖 Generated with [Claude Code](https://claude.com/claude-code)