### PR TITLE
Fix deploy script: use relative publicPath

### DIFF
--- a/scripts/deploy
+++ b/scripts/deploy
@@ -2,7 +2,7 @@
 
 # build
 
-npm run build:mainnet https://swaponline.github.io/
+npm run build:mainnet ./
 
 # update repo or clone
 
@@ -27,7 +27,7 @@ cp -rf ../build-mainnet/* ./
 
 # commit build to repo
 
-DATE=`updated '+%Y-%m-%d %H:%M:%S'`
+DATE=`date '+%Y-%m-%d %H:%M:%S'`
 git add .
 git commit -m "build $DATE"
 git push --force


### PR DESCRIPTION
## Summary
- Fixed deploy script to use relative publicPath `./` instead of absolute URL
- Fixed typo in date command (`updated` -> `date`)
- This fixes 404 errors for CSS/JS files on production

## Root Cause
The deploy script was passing `https://swaponline.github.io/` as publicPath, causing webpack to generate absolute URLs in index.html. GitHub Pages needs relative paths.

## Changes
1. `scripts/deploy`: Changed `npm run build:mainnet https://swaponline.github.io/` to `npm run build:mainnet ./`
2. Fixed `DATE=updated` to `DATE=date`

## Test Plan
- [x] Local build with relative path produces correct index.html
- [ ] After merge, GitHub Actions will deploy and https://swaponline.github.io/ should load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)