### PR TITLE
Fix build failures: remove BUILD_OUTPUT_PATH and improve error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "build:testnet-tests": "npm run clean:testnet && cross-env DEBUG=app:* IS_TEST=true CONFIG=testnet.prod node ./src/front/bin/compile",
     "build:testnet-tests-old": "npm run clean:testnet && cross-env DEBUG=app:* IS_TEST=true CONFIG=testnet.prod node --max-old-space-size=5120 ./src/front/bin/compile",
     "build:testnet-widget": "npm run clean:testnet-widget && cross-env BUILD_TYPE=testnet DEBUG=app:* CONFIG=testnet.widget.prod node --max-old-space-size=5120 ./src/front/bin/compile",
-    "build:mainnet": "cross-env NODE_ENV=production DEBUG=app:* CONFIG=mainnet.prod BUILD_OUTPUT_PATH=/var/www/mcw2.wpmix.net node --max-old-space-size=4096 ./src/front/bin/compile",
+    "build:mainnet": "cross-env NODE_ENV=production DEBUG=app:* CONFIG=mainnet.prod node --max-old-space-size=4096 ./src/front/bin/compile",
     "build:mainnet-widget": "npm run clean:mainnet-widget && cross-env NODE_ENV=production BUILD_TYPE=mainnet DEBUG=app:* CONFIG=mainnet.widget.prod node --max-old-space-size=5120 ./src/front/bin/compile",
     "build:testnet-local": "npm run clean:testnet-local && cross-env DEBUG=app:* CONFIG=testnet-local.prod node --max-old-space-size=5120 ./src/front/bin/compile",
     "build:mainnet-local": "npm run clean:mainnet-local && cross-env NODE_ENV=production DEBUG=app:* CONFIG=mainnet-local.prod node --max-old-space-size=5120 ./src/front/bin/compile",

--- a/src/front/bin/compile/compile.js
+++ b/src/front/bin/compile/compile.js
@@ -12,6 +12,16 @@ debug(`Environment is set to: ${process.env.NODE_ENV || 'default'}`)
 debug('Webpack compiler starting to build')
 
 compiler.run((err, stats) => {
+  if (err) {
+    debug(chalk.red(err))
+    process.exit(1)
+  }
+
+  if (!stats) {
+    debug(chalk.red('Webpack compilation failed with no stats'))
+    process.exit(1)
+  }
+
   const jsonStats = stats.toJson()
 
   debug('Compilation completed!')
@@ -22,11 +32,7 @@ compiler.run((err, stats) => {
     chunks: false,
   }))
 
-  if (err) {
-    debug(chalk.red(err))
-    process.exit(1)
-  }
-  else if (jsonStats.errors.length > 0) {
+  if (jsonStats.errors.length > 0) {
     debug(chalk.red(jsonStats.errors))
     process.exit(1)
   }


### PR DESCRIPTION
## Summary
- Removed BUILD_OUTPUT_PATH from build:mainnet (was causing build to write to non-existent /var/www/ path)
- Fixed compile.js to properly handle webpack errors
- Build now outputs to default build-mainnet/ directory

## Root Cause
Previous deploys (#5272, #5273) failed because:
1. BUILD_OUTPUT_PATH=/var/www/mcw2.wpmix.net doesn't exist in GitHub Actions
2. When webpack failed, compile.js crashed trying to call stats.toJson() on undefined

## Changes
1. `package.json`: Removed BUILD_OUTPUT_PATH from build:mainnet command
2. `src/front/bin/compile/compile.js`: Check err and stats before calling stats.toJson()

## Test Plan
- [x] Local build completes successfully
- [ ] After merge, GitHub Actions should build to build-mainnet/ and deploy to Pages

Related: #5272, #5273

🤖 Generated with [Claude Code](https://claude.com/claude-code)