### PR TITLE
fix: enable Apps by default and update Polygon RPC

### DIFF
--- a/src/front/config/mainnet/web3.js
+++ b/src/front/config/mainnet/web3.js
@@ -1,7 +1,7 @@
 export default {
   provider: 'https://mainnet.infura.io/v3/{INFURA_API_KEY}',
   binance_provider: 'https://bsc-dataseed.binance.org/',
-  matic_provider: 'https://polygon-bor-rpc.publicnode.com',
+  matic_provider: 'https://rpc.ankr.com/polygon/afbbed6c16c518a252ca00b02d488e4ce457fb930b5f2aff5437a3a5191fb731',
   arbitrum_provider: 'https://arb1.arbitrum.io/rpc',
   xdai_provider: 'https://rpc.gnosischain.com',
   ftm_provider: 'https://rpc.ftm.tools',

--- a/src/front/shared/helpers/externalConfig.ts
+++ b/src/front/shared/helpers/externalConfig.ts
@@ -137,7 +137,7 @@ const externalConfig = () => {
         after: []
       },
       apps: {
-        enabled: false,
+        enabled: true,
         headerPinnedIds: [],
         replaceExchangeWithAppId: '',
       },


### PR DESCRIPTION
## Summary
- Enable wallet apps feature by default (`config.opts.ui.apps.enabled = true`)
- Update Polygon RPC endpoint to working Ankr URL

## Problem
1. Apps page (`/apps`) was empty on production because `config.opts.ui.apps.enabled` defaulted to `false`
2. Console showed Polygon RPC 401 errors from `polygon-bor-rpc.publicnode.com`

## Changes
1. `src/front/shared/helpers/externalConfig.ts:140` - Changed `enabled: false` to `enabled: true`
2. `src/front/config/mainnet/web3.js:4` - Updated `matic_provider` to Ankr endpoint

## Verification
After merge + auto-deploy:
- Visit https://swaponline.github.io/#/apps - should show Apps page (not empty)
- Open console - no more Polygon 401 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)